### PR TITLE
Add unique identifier to IDs in heading

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -28,7 +28,7 @@ Renderer.prototype.heading = function(text, level){
     headingId[id] = 1;
   }
 
-  return '<h' + level + ' id="' + id + '">' + text + '</h' + level + '>';
+  return '<h' + level + ' id="__' + id + '">' + text + '</h' + level + '>';
 };
 
 function anchorId(str){

--- a/test/index.js
+++ b/test/index.js
@@ -30,9 +30,9 @@ describe('Marked renderer', function(){
     var result = r({text: body});
 
     result.should.eql([
-      '<h1 id="Hello_world">Hello world</h1>',
+      '<h1 id="__Hello_world">Hello world</h1>',
       '<pre><code>' + util.highlight(code, {gutter: false, wrap: false}) + '\n</code></pre>',
-      '<h2 id="Hello_world-1">Hello world</h2>',
+      '<h2 id="__Hello_world-1">Hello world</h2>',
       '<p>hello</p>'
     ].join('') + '\n');
   });


### PR DESCRIPTION
In case of clashing with CSS style.

For example, a `## footer`  will generate `<h2 id="footer">footer</h2>`, and `#footer` may have predefined styles. This is unexpected behaviour.