### PR TITLE
Prepend root path to img and link

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -4,14 +4,17 @@ var marked = require('marked');
 var assign = require('object-assign');
 var stripIndent = require('strip-indent');
 var util = require('hexo-util');
+
 var highlight = util.highlight;
 var stripHTML = util.stripHTML;
 var MarkedRenderer = marked.Renderer;
 
-function Renderer() {
+function Renderer(ctx) {
   MarkedRenderer.apply(this, arguments);
 
   this._headingId = {};
+  this.ctx = ctx;
+  this.url_for = ctx.extend.helper.get('url_for');
 }
 
 require('util').inherits(Renderer, MarkedRenderer);
@@ -29,6 +32,16 @@ Renderer.prototype.heading = function(text, level) {
   }
   // add headerlink
   return '<h' + level + ' id="' + id + '"><a href="#' + id + '" class="headerlink" title="' + stripHTML(text) + '"></a>' + text + '</h' + level + '>';
+};
+
+Renderer.prototype.link = function(href, title, text) {
+  href = this.url_for.call(this.ctx, href);
+  return MarkedRenderer.prototype.link.call(this, href, title, text);
+};
+
+Renderer.prototype.image = function(href, title, text) {
+  href = this.url_for.call(this.ctx, href);
+  return MarkedRenderer.prototype.image.call(this, href, title, text);
 };
 
 function anchorId(str) {
@@ -52,6 +65,6 @@ marked.setOptions({
 
 module.exports = function(data, options) {
   return marked(data.text, assign({
-    renderer: new Renderer()
+    renderer: new Renderer(this)
   }, this.config.marked, options));
 };


### PR DESCRIPTION
In hexo configuration, if the root path is set to a sub directory, hexo
should prepend this root path to img and link of markdown syntax.

Resolves: https://github.com/hexojs/hexo/issues/1440