### PR TITLE
Adds the base path to relative links

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -4,6 +4,7 @@ var marked = require('marked');
 var assign = require('object-assign');
 var stripIndent = require('strip-indent');
 var util = require('hexo-util');
+var path = require('path');
 var highlight = util.highlight;
 var stripHTML = util.stripHTML;
 var MarkedRenderer = marked.Renderer;
@@ -31,6 +32,32 @@ Renderer.prototype.heading = function(text, level){
   return '<h' + level + ' id="' + id + '">' + text + '</h' + level + '>';
 };
 
+Renderer.prototype.link = function(href, title,text){
+  
+  href = addBaseLink(href); 
+  
+  return MarkedRenderer.prototype.link.call(this, href, title, text);
+};
+
+Renderer.prototype.image = function(href, title, text){
+  
+  href = addBaseLink(href);
+  
+  return MarkedRenderer.prototype.image.call(this, href, title, text);
+};
+
+function addBaseLink(href){
+  
+  // Add baseLink if relative href
+  var expScheme = /^((http|https|ftp):\/\/)/;
+  
+  if(!expScheme.test(href) && href.charAt(0) !== '/' && (href.charAt(0) !== '.')) {
+        href = this.options.baseLink + href;
+  }
+  return href;
+  
+}
+
 function anchorId(str){
   return str
     .replace(/\s+/g, '_')
@@ -50,6 +77,20 @@ marked.setOptions({
 });
 
 module.exports = function(data, options){
+  
+  var postPath = path.join(this.source.context.source_dir, '_posts');
+  var pathDir = path.parse(data.path).dir;
+  var dirFromBase = path.join(path.sep, path.relative(postPath, pathDir), path.sep);
+  var pathBaseUrl = dirFromBase.split(path.sep).join('/');  
+  
+  // this.log.info('marked postDir: ', postPath);  
+  // this.log.info('marked data.path: ', data.path);  
+  // this.log.info('marked pathDir: ', pathDir);
+  // this.log.info('marked dirFromBase: ', dirFromBase);
+  // this.log.info('marked pathBaseUrl: ', pathBaseUrl);
+  
+  options.baseLink = pathBaseUrl;
+  
   return marked(data.text, assign({
     renderer: new Renderer()
   }, this.config.marked, options));


### PR DESCRIPTION
Get base url from path of markdown file and update href to relative href.

For a markdown file written in source `/_posts/Debian/NodeJs.md`
and an image stored in source `/_posts/Debian/NodeJS/logo.png`

The following code markdown
```
![nodejs](NodeJs/logo.png)
```

After rendering the `href` is completed by the base path if it does not start with `http[s]://`.
```
<img src="/Debian/NodeJs/logo.png" alt="nodejs">
```
