### PR TITLE
No prefix for anchor links

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -35,7 +35,10 @@ Renderer.prototype.heading = function(text, level) {
 };
 
 Renderer.prototype.link = function(href, title, text) {
-  href = this.url_for.call(this.ctx, href);
+  if (href.indexOf('#') !== 0) {
+    href = this.url_for.call(this.ctx, href);
+  }
+
   return MarkedRenderer.prototype.link.call(this, href, title, text);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,8 @@ describe('Marked renderer', function() {
       '',
       '[link text](/path/to/link)',
       '',
+      '[link to anchor](#Hello_world)',
+      '',
       '![img](/path/to/img)'
     ].join('\n');
 
@@ -67,6 +69,7 @@ describe('Marked renderer', function() {
         '<h2 id="Hello_world-1"><a href="#Hello_world-1" class="headerlink" title="Hello world"></a>Hello world</h2>',
         '<p>hello</p>\n',
         '<p><a href="/path/to/link">link text</a></p>\n',
+        '<p><a href="#Hello_world">link to anchor</a></p>\n',
         '<p><img src="/path/to/img" alt="img"></p>'
       ].join('') + '\n');
 
@@ -78,6 +81,7 @@ describe('Marked renderer', function() {
         '<h2 id="Hello_world-1"><a href="#Hello_world-1" class="headerlink" title="Hello world"></a>Hello world</h2>',
         '<p>hello</p>\n',
         '<p><a href="/root/path/to/link">link text</a></p>\n',
+        '<p><a href="#Hello_world">link to anchor</a></p>\n',
         '<p><img src="/root/path/to/img" alt="img"></p>'
       ].join('') + '\n');
   });


### PR DESCRIPTION
Inserting links to headings directly from markdown is common practice. `[jump to title](#title)` should not become a full-blown URL on markdown rendering. It should instead be rendered as-is: `<a href="#title">jump to title</a>`.