### PR TITLE
锚点 id 为中文时，Safari中某些元素点击无效

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -34,7 +34,9 @@ Renderer.prototype.listitem = function(text) {
 // Add id attribute to headings
 Renderer.prototype.heading = function(text, level) {
   var transformOption = this.options.modifyAnchors;
-  var id = anchorId(stripHTML(text), transformOption);
+  // var id = anchorId(stripHTML(text), transformOption);
+  // 锚点 id 为中文时，IOS & PC端的Safari导致页面某些元素点击无效，故编码。
+  var id = escape(anchorId(stripHTML(text), transformOption)).replace(/\%u|\%U/g,'');
   var headingId = this._headingId;
 
   // Add a number after id if repeated

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -34,8 +34,7 @@ Renderer.prototype.listitem = function(text) {
 // Add id attribute to headings
 Renderer.prototype.heading = function(text, level) {
   var transformOption = this.options.modifyAnchors;
-  // var id = anchorId(stripHTML(text), transformOption);
-  // 锚点 id 为中文时，IOS & PC端的Safari导致页面某些元素点击无效，故编码。
+  // Fixed: anchor ID is Chinese, and some elements in Safari are invalid
   var id = escape(anchorId(stripHTML(text), transformOption)).replace(/\%u|\%U/g,'');
   var headingId = this._headingId;
 


### PR DESCRIPTION
锚点 id 为中文时，IOS & PC端的Safari导致页面某些元素点击无效，故编码。