### PR TITLE
Add swigRaw option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ marked:
   smartLists: true
   smartypants: true
   modifyAnchors: ''
-  autolink: true
+  autolink: true,
+  swigRaw: false
 ```
 
 - **gfm** - Enables [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown)
@@ -39,6 +40,7 @@ marked:
 - **smartypants** - Use "smart" typograhic punctuation for things like quotes and dashes.
 - **modifyAnchors** - Use for transform anchorIds. if 1 to lowerCase and if 2 to upperCase.
 - **autolink** - Enable autolink for URLs. E.g. `http://hexo.io` will become `<a href="http://hexo.io">http://hexo.io</a>`.
+- **swigRaw** - Escape the output in a swig `{% raw %}` tag. This will keep your template from being parse by the default hexo swig renderer.
 
 [Markdown]: http://daringfireball.net/projects/markdown/
 [marked]: https://github.com/chjj/marked

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ hexo.config.marked = assign({
   smartLists: true,
   smartypants: true,
   modifyAnchors: '',
-  autolink: true
+  autolink: true,
+  swigRaw: false
 }, hexo.config.marked);
 
 hexo.extend.renderer.register('md', 'html', renderer, true);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -95,7 +95,15 @@ marked.setOptions({
 });
 
 module.exports = function(data, options) {
-  return marked(data.text, assign({
+  let mergedOptions = assign({
     renderer: new Renderer()
-  }, this.config.marked, options));
+  }, this.config.marked, options);
+
+  let rendered = marked(data.text, mergedOptions);
+
+  if (mergedOptions.swigRaw) {
+    rendered = '{% raw %}' + rendered + '{% endraw %}';
+  }
+
+  return rendered;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -177,4 +177,28 @@ describe('Marked renderer', function() {
       ].join('\n'));
     });
   });
+
+  describe('swigRaw option true', function() {
+    var ctx = {
+      config: {
+        marked: {
+          swigRaw: true
+        }
+      }
+    };
+
+    var renderer = require('../lib/renderer');
+
+    var body = '{{foo}}';
+
+    it('returnd values are escaped', function() {
+      var r = renderer.bind(ctx);
+      var result = r({text: body});
+
+      result.should.eql([
+        '{% raw %}<p>{{foo}}</p>',
+        '{% endraw %}'
+      ].join('\n'));
+    });
+  });
 });


### PR DESCRIPTION
Writers may not want their HTML to be processed by the swig templating system that hexo applies to HTML by default. Offer an option to disable swig from template via the `{% raw %}` tag.