### PR TITLE
Add support for basic description/definition lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM Dependencies](https://david-dm.org/hexojs/hexo-renderer-marked.svg)](https://david-dm.org/hexojs/hexo-renderer-marked)
 [![NPM DevDependencies](https://david-dm.org/hexojs/hexo-renderer-marked/dev-status.svg)](https://david-dm.org/hexojs/hexo-renderer-marked?type=dev)
 
-Add support for [Markdown]. This plugin uses [marked] as render engine.
+Add support for [Markdown]. This plugin uses [marked] as its render engine.
 
 ## Installation
 
@@ -42,5 +42,49 @@ marked:
 - **modifyAnchors** - Use for transform anchorIds. if 1 to lowerCase and if 2 to upperCase.
 - **autolink** - Enable autolink for URLs. E.g. `https://hexo.io` will become `<a href="https://hexo.io">https://hexo.io</a>`.
 
+## Extras
+
+### Definition/Description Lists
+
+`hexo-renderer-marked` also implements description/definition lists using the same syntax as [PHP Markdown Extra][PHP Markdown Extra].
+
+This Markdown:
+
+```markdown
+Definition Term
+:    This is the definition for the term
+```
+
+will generate this html:
+
+```html
+<dl>
+  <dt>Definition Term</dt>
+  <dd>This is the definition for the term</dd>
+</dl>
+```
+
+Note: There is currently a limitation in this implementation. If multiple definitions are provided, the rendered HTML will be incorrect.
+
+For example, this Markdown:
+
+```markdown
+Definition Term
+:    Definition 1
+:    Definition 2
+```
+
+will generate this HTML:
+
+```html
+<dl>
+  <dt>Definition Term<br>: Definition 1</dt>
+  <dd>Definition 2</dd>
+</dl>
+```
+
+If you've got ideas on how to support multiple definitions, please provide a pull request. We'd love to support it.
+
 [Markdown]: https://daringfireball.net/projects/markdown/
 [marked]: https://github.com/chjj/marked
+[PHP Markdown Extra]: https://michelf.ca/projects/php-markdown/extra/#def-list

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -85,20 +85,23 @@ Renderer.prototype.link = function(href, title, text) {
 
 // Support Basic Description Lists
 Renderer.prototype.paragraph = function(text) {
-  var dlTest = /(^|\s)(\S.+)(<br>\:(\s+))(\S.+)/;
+  var result = '';
+  var dlTest = /(^|\s)(\S.+)(<br>:(\s+))(\S.+)/;
 
-  var dl =
-    "<dl>" +
-      "<dt>$2</dt>" +
-      "<dd>$5</dd>" +
-    "</dl>";
+  var dl
+    = '<dl>'
+      + '<dt>$2</dt>'
+      + '<dd>$5</dd>'
+    + '</dl>';
 
-if (text.match(dlTest)) {
-    return text.replace(dlTest, dl);
+  if (text.match(dlTest)) {
+    result = text.replace(dlTest, dl);
   } else {
-    return "<p>" + text + "</p>\n";
+    result = '<p>' + text + '</p>\n';
   }
-}
+
+  return result;
+};
 
 marked.setOptions({
   langPrefix: '',

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -85,7 +85,7 @@ Renderer.prototype.link = function(href, title, text) {
 
 // Support Basic Description Lists
 Renderer.prototype.paragraph = function(text) {
-  var dlTest = /(^|\s)(\S.+)(<br>\:(\s*))(\S.+)/;
+  var dlTest = /(^|\s)(\S.+)(<br>\:(\s+))(\S.+)/;
 
   var dl =
     "<dl>" +
@@ -96,7 +96,7 @@ Renderer.prototype.paragraph = function(text) {
 if (text.match(dlTest)) {
     return text.replace(dlTest, dl);
   } else {
-    return "<p>" + text + "</p>";
+    return "<p>" + text + "</p>\n";
   }
 }
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -83,6 +83,23 @@ Renderer.prototype.link = function(href, title, text) {
   return out;
 };
 
+// Support Basic Description Lists
+Renderer.prototype.paragraph = function(text) {
+  var dlTest = /(^|\s)(\S.+)(<br>\:(\s*))(\S.+)/;
+
+  var dl =
+    "<dl>" +
+      "<dt>$2</dt>" +
+      "<dd>$5</dd>" +
+    "</dl>";
+
+if (text.match(dlTest)) {
+    return text.replace(dlTest, dl);
+  } else {
+    return "<p>" + text + "</p>";
+  }
+}
+
 marked.setOptions({
   langPrefix: '',
   highlight: function(code, lang) {

--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,33 @@ describe('Marked renderer', function() {
     ].join(''));
   });
 
+  // Description List tests
+
+  it('should render description lists with a single space after the colon', function() {
+    var result = r({text: 'Description Term<br>: This is the Description'});
+    result.should.eql('<dl><dt>Description Term</dt><dd>This is the Description</dd></dl>');
+  });
+
+  it('should render description lists with multiple spaces after the colon', function() {
+    var result = r({text: 'Description Term<br>:    This is the Description'});
+    result.should.eql('<dl><dt>Description Term</dt><dd>This is the Description</dd></dl>');
+  });
+
+  it('should render description lists with a tab after the colon', function() {
+    var result = r({text: 'Description Term<br>:	This is the Description'});
+    result.should.eql('<dl><dt>Description Term</dt><dd>This is the Description</dd></dl>');
+  });
+
+  it('should render description lists with a carriage return after the colon', function() {
+    var result = r({text: 'Description Term<br>:\nThis is the Description'});
+    result.should.eql('<dl><dt>Description Term</dt><dd>This is the Description</dd></dl>');
+  });
+
+  it('should not render regular paragraphs as description lists', function() {
+    var result = r({text: 'Description Term<br>:This is the Description'});
+    result.should.eql('<p>Description Term<br>:This is the Description</p>\n');
+  });
+
   describe('autolink option tests', function() {
     var ctx = {
       config: {


### PR DESCRIPTION
I find myself using descriptions lists, so I've added support for them in my Hexo setup, and want to offer it here to be included in the main repo. This will turn a [PHP Markdown style definition list](https://michelf.ca/projects/php-markdown/extra/#def-list) into the correct definition list html.

So this Markdown:

```markdown
Definition Term
:    This is the definition for the term
```

Will generate this html:

```html
<dl>
  <dt>Definition Term</dt>
  <dd>This is the definition for the term</dd>
</dl>
```

There is a limitation in the `<dd>`. This only supports single definitions. The above Markdown will work, but this will not:

```markdown
Definition Term
:    Definition 1
:    Definition 2
```

That Markdown will generate this html:

```html
<dl>
  <dt>Definition Term<br>: Definition 1</dt>
  <dd>Definition 2</dd>
</dl>
```

If you've got ideas on how to support multiple definitions, I'd love to add that.