### PR TITLE
Add anchorAlias option and fix heading id collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ marked:
 - **smartLists** - Use smarter list behavior than the original markdown.
 - **smartypants** - Use "smart" typograhic punctuation for things like quotes and dashes.
 - **modifyAnchors** - Use for transform anchorIds. if 1 to lowerCase and if 2 to upperCase.
-- **anchorAlias** - For link in headings, use href as anchor ID alias. E.g. `## [Anchor](#alias)` will become `<h2><a href="#alias">Anchor</a></h2>`
+- **anchorAlias** - For link in headings, use href as anchor ID alias. E.g. `## [Anchor](#alias)` will become `<h2 id="alias"><a href="#alias">Anchor</a></h2>`
 - **autolink** - Enable autolink for URLs. E.g. `https://hexo.io` will become `<a href="https://hexo.io">https://hexo.io</a>`.
 
 ## Extras

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ marked:
   smartLists: true
   smartypants: true
   modifyAnchors: ''
+  anchorAlias: false
   autolink: true
 ```
 
@@ -40,6 +41,7 @@ marked:
 - **smartLists** - Use smarter list behavior than the original markdown.
 - **smartypants** - Use "smart" typograhic punctuation for things like quotes and dashes.
 - **modifyAnchors** - Use for transform anchorIds. if 1 to lowerCase and if 2 to upperCase.
+- **anchorAlias** - For link in headings, use href as anchor ID alias. E.g. `## [Anchor](#alias)` will become `<h2><a href="#alias">Anchor</a></h2>`
 - **autolink** - Enable autolink for URLs. E.g. `https://hexo.io` will become `<a href="https://hexo.io">https://hexo.io</a>`.
 
 ## Extras

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ hexo.config.marked = assign({
   smartLists: true,
   smartypants: true,
   modifyAnchors: '',
+  anchorAlias: false,
   autolink: true
 }, hexo.config.marked);
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -31,7 +31,6 @@ Renderer.prototype.listitem = function(text) {
   return result;
 };
 
-
 // Add id attribute to headings
 Renderer.prototype.heading = function(text, level) {
   var transformOption = this.options.modifyAnchors;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -31,20 +31,52 @@ Renderer.prototype.listitem = function(text) {
   return result;
 };
 
+
 // Add id attribute to headings
 Renderer.prototype.heading = function(text, level) {
   var transformOption = this.options.modifyAnchors;
-  var id = anchorId(stripHTML(text), transformOption);
+  var aliasOption = this.options.anchorAlias;
+
+  var hrefRegex = /(<a\s+(?:[^>]*?\s+)?href=(["']))(.*?)\2/i;
+  var matches = text.match(hrefRegex);
+  var isLink = matches && matches[3] && matches[3].startsWith('#');
+  var innerText = stripHTML(text);
+  var idText = innerText;
+
+  // Use href attribute as id
+  if (aliasOption && isLink) {
+    idText = matches[3];
+    if (!idText) {
+      idText = innerText;
+    }
+  }
+
+  // For `[]()`
+  if (!innerText && !idText) {
+    return '<h' + level + '></h' + level + '>';
+  }
+
+  var id = anchorId(idText, transformOption);
   var headingId = this._headingId;
 
   // Add a number after id if repeated
+  // Add output id back to the map for collision resistance
   if (headingId[id]) {
     id += '-' + headingId[id]++;
+    headingId[id] = 1;
   } else {
     headingId[id] = 1;
   }
+
+  // if `text` is a <a> element, replace the href with the generated id;
+  // else, `text` is plain string, just keep it.
+  var innerHTML = text;
+  if (isLink) {
+    innerHTML = text.replace(hrefRegex, '$1#' + id + '$2');
+  }
+
   // add headerlink
-  return '<h' + level + ' id="' + id + '"><a href="#' + id + '" class="headerlink" title="' + stripHTML(text) + '"></a>' + text + '</h' + level + '>';
+  return '<h' + level + ' id="' + id + '"><a href="#' + id + '" class="headerlink" title="' + innerText + '"></a>' + innerHTML + '</h' + level + '>';
 };
 
 function anchorId(str, transformOption) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -37,6 +37,7 @@ Renderer.prototype.heading = function(text, level) {
   var transformOption = this.options.modifyAnchors;
   var aliasOption = this.options.anchorAlias;
 
+  // https://regex101.com/r/Kw7KzC/1
   var hrefRegex = /(<a\s+(?:[^>]*?\s+)?href=(["']))(.*?)\2/i;
   var matches = text.match(hrefRegex);
   var isLink = matches && matches[3] && matches[3].startsWith('#');
@@ -46,9 +47,6 @@ Renderer.prototype.heading = function(text, level) {
   // Use href attribute as id
   if (aliasOption && isLink) {
     idText = matches[3];
-    if (!idText) {
-      idText = innerText;
-    }
   }
 
   // For `[]()`

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,33 @@ describe('Marked renderer', function() {
     ].join(''));
   });
 
+  it('should render headings with id collision', function() {
+    var body = [
+      '## example',
+      '',
+      '# example',
+      '',
+      '## example-1',
+      '',
+      '### example',
+      '',
+      '#### example-2',
+      '',
+      '## example-1'
+    ].join('\n');
+
+    var result = r({text: body});
+
+    result.should.eql([
+      '<h2 id="example"><a href="#example" class="headerlink" title="example"></a>example</h2>',
+      '<h1 id="example-1"><a href="#example-1" class="headerlink" title="example"></a>example</h1>',
+      '<h2 id="example-1-1"><a href="#example-1-1" class="headerlink" title="example-1"></a>example-1</h2>',
+      '<h3 id="example-2"><a href="#example-2" class="headerlink" title="example"></a>example</h3>',
+      '<h4 id="example-2-1"><a href="#example-2-1" class="headerlink" title="example-2"></a>example-2</h4>',
+      '<h2 id="example-1-2"><a href="#example-1-2" class="headerlink" title="example-1"></a>example-1</h2>'
+    ].join(''));
+  });
+
   it('should handle chinese headers properly', function() {
     var body = '# 中文';
     var result = r({text: body});
@@ -202,6 +229,79 @@ describe('Marked renderer', function() {
         '</ul>',
         '<h1 id=\"example\"><a href=\"#example\" class=\"headerlink\" title=\"Example\"></a>Example</h1>'
       ].join('\n'));
+    });
+  });
+
+  describe('anchorAlias option tests', function() {
+    var body = [
+      '# example',
+      '',
+      '## example',
+      '',
+      '### [example-1]',
+      '',
+      '#### [example](http://example.com)',
+      '',
+      '##### example-2',
+      '',
+      '# [example-1](#example)',
+      '',
+      '## [example](#example-1)',
+      '',
+      '### [example](#example-anchor)',
+      '',
+      '#### [中文](#chinese)',
+      '',
+      '##### []()',
+      '',
+      '[example-1]: http://example.com'
+    ].join('\n');
+
+    var renderer = require('../lib/renderer');
+
+    var ctx = {
+      config: {
+        marked: {
+          anchorAlias: false
+        }
+      }
+    };
+
+    it('should not modify anchors with default options', function() {
+      var r = renderer.bind(ctx);
+      var result = r({text: body});
+
+      result.should.eql([
+        '<h1 id="example"><a href="#example" class="headerlink" title="example"></a>example</h1>',
+        '<h2 id="example-1"><a href="#example-1" class="headerlink" title="example"></a>example</h2>',
+        '<h3 id="example-1-1"><a href="#example-1-1" class="headerlink" title="example-1"></a><a href="http://example.com">example-1</a></h3>',
+        '<h4 id="example-2"><a href="#example-2" class="headerlink" title="example"></a><a href="http://example.com">example</a></h4>',
+        '<h5 id="example-2-1"><a href="#example-2-1" class="headerlink" title="example-2"></a>example-2</h5>',
+        '<h1 id="example-1-2"><a href="#example-1-2" class="headerlink" title="example-1"></a><a href="#example-1-2">example-1</a></h1>',
+        '<h2 id="example-3"><a href="#example-3" class="headerlink" title="example"></a><a href="#example-3">example</a></h2>',
+        '<h3 id="example-4"><a href="#example-4" class="headerlink" title="example"></a><a href="#example-4">example</a></h3>',
+        '<h4 id="中文"><a href="#中文" class="headerlink" title="中文"></a><a href="#中文">中文</a></h4>',
+        '<h5></h5>'
+      ].join(''));
+    });
+
+    it('should us link as id with anchorAlias option set to true', function() {
+      ctx.config.marked.anchorAlias = 1;
+      var r = renderer.bind(ctx);
+      var result = r({text: body});
+
+      result.should.eql([
+        '<h1 id="example"><a href="#example" class="headerlink" title="example"></a>example</h1>',
+        '<h2 id="example-1"><a href="#example-1" class="headerlink" title="example"></a>example</h2>',
+        '<h3 id="example-1-1"><a href="#example-1-1" class="headerlink" title="example-1"></a><a href="http://example.com">example-1</a></h3>',
+        '<h4 id="example-2"><a href="#example-2" class="headerlink" title="example"></a><a href="http://example.com">example</a></h4>',
+        '<h5 id="example-2-1"><a href="#example-2-1" class="headerlink" title="example-2"></a>example-2</h5>',
+        '<h1 id="example-3"><a href="#example-3" class="headerlink" title="example-1"></a><a href="#example-3">example-1</a></h1>',
+        '<h2 id="example-1-2"><a href="#example-1-2" class="headerlink" title="example"></a><a href="#example-1-2">example</a></h2>',
+        '<h3 id="example-anchor"><a href="#example-anchor" class="headerlink" title="example"></a><a href="#example-anchor">example</a></h3>',
+        '<h4 id="chinese"><a href="#chinese" class="headerlink" title="中文"></a><a href="#chinese">中文</a></h4>',
+        '<h5></h5>'
+      ].join(''));
     });
   });
 });


### PR DESCRIPTION
> Read more in [Chinese](https://mdluo.com/2018-02-11/heading-anchors-in-hexo/) about this PR.

#### 1. Add an `anchorAlias` option (`false` by default) to let user to use href as anchor ID alias.

E.g. Markdown source code:

```md
## [Anchor](#alias)
```

will become the following html code if the `anchorAlias` is set to `true`:

```html
<h2 id="alias"><a href="#alias">Anchor</a></h2>
```

#### 2. Fix heading id collisions.

E.g.

```md
## example
## example
## example-1
```

####  3. Update README and add comment of the new option.

####  4. Add testing code for the new option and the fix. The coverage is 100% for the modified code.
