### PR TITLE
Add support for KaTeX

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var marked = require('marked');
+var katex = require('katex');
 var assign = require('object-assign');
 var stripIndent = require('strip-indent');
 var util = require('hexo-util');
@@ -106,6 +107,14 @@ Renderer.prototype.paragraph = function(text) {
 marked.setOptions({
   langPrefix: '',
   highlight: function(code, lang) {
+    switch (String(lang).toLowerCase()) {
+    case 'math':
+    case 'katex':
+    case 'latex':
+      return katex.renderToString(code, {
+        throwOnError: false
+      });
+    }
     return highlight(stripIndent(code), {
       lang: lang,
       gutter: false,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "hexo-util": "^0.6.2",
+    "katex": "^0.10.0-beta",
     "marked": "^0.3.9",
     "object-assign": "^4.1.1",
     "strip-indent": "^2.0.0"


### PR DESCRIPTION
If the lang of code is math, katex, or latex, the code will be rendered in katex format.