### PR TITLE
refactor(package): delete object-assign package and use Object.assign instead of it

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,8 @@
 'use strict';
 
 var renderer = require('./lib/renderer');
-var assign = require('object-assign');
 
-hexo.config.marked = assign({
+hexo.config.marked = Object.assign({
   gfm: true,
   pedantic: false,
   sanitize: false,

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var marked = require('marked');
-var assign = require('object-assign');
 var stripIndent = require('strip-indent');
 var util = require('hexo-util');
 
@@ -101,7 +100,7 @@ marked.setOptions({
 });
 
 module.exports = function(data, options) {
-  return marked(data.text, assign({
+  return marked(data.text, Object.assign({
     renderer: new Renderer()
   }, this.config.marked, options));
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "hexo-util": "^0.6.2",
     "marked": "^0.6.1",
-    "object-assign": "^4.1.1",
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Proposal

Object.assign can use instead of object-assign package.
