### PR TITLE
chore: specify node version to 6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "eslint-config-hexo": "^3.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^6.0.0"
+  },
+  "engines": {
+    "node": ">=6.9.0"
   }
 }


### PR DESCRIPTION
Set node version to 6.9 same with [hexo](https://github.com/hexojs/hexo/blob/a6dc0ea28dddad1b5f1bad7c6f86f1e0627b564a/package.json#L82).