### PR TITLE
chore: specify files in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-test/
-tmp/
-coverage/
-*.log
-.jshintrc
-.travis.yml
-gulpfile.js
-.idea/
-appveyor.yml

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "directories": {
     "lib": "./lib"
   },
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "repository": "hexojs/hexo-renderer-marked",
   "keywords": [
     "hexo",


### PR DESCRIPTION
Specified `files` in package.jso and removed outdated `.npmignore`.

Shrinked our packed size from 4.6KB to 3.6KB.