### PR TITLE
chore(deps): update marked to ^0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ marked:
   smartypants: true
   modifyAnchors: ''
   autolink: true
+  sanitizeUrl: false
 ```
 
 - **gfm** - Enables [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown)
@@ -37,6 +38,7 @@ marked:
 - **smartypants** - Use "smart" typograhic punctuation for things like quotes and dashes.
 - **modifyAnchors** - Use for transform anchorIds. if `1` to lowerCase and if `2` to upperCase. **Must be integer**.
 - **autolink** - Enable autolink for URLs. E.g. `https://hexo.io` will become `<a href="https://hexo.io">https://hexo.io</a>`.
+- **sanitizeUrl** - Remove URLs that start with `javascript:`, `vbscript:` and `data:`.
 
 ## Extras
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ You can configure this plugin in `_config.yml`.
 marked:
   gfm: true
   pedantic: false
-  sanitize: false
-  tables: true
   breaks: true
   smartLists: true
   smartypants: true
@@ -34,8 +32,6 @@ marked:
 
 - **gfm** - Enables [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown)
 - **pedantic** - Conform to obscure parts of `markdown.pl` as much as possible. Don't fix any of the original markdown bugs or poor behavior.
-- **sanitize** - Sanitize the output. Ignore any HTML that has been input.
-- **tables** - Enable GFM [tables](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#wiki-tables). This option requires the `gfm` option to be true.
 - **breaks** - Enable GFM [line breaks](https://help.github.com/articles/github-flavored-markdown#newlines). This option requires the `gfm` option to be true.
 - **smartLists** - Use smarter list behavior than the original markdown.
 - **smartypants** - Use "smart" typograhic punctuation for things like quotes and dashes.

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var renderer = require('./lib/renderer');
 hexo.config.marked = Object.assign({
   gfm: true,
   pedantic: false,
-  sanitize: false,
-  tables: true,
   breaks: true,
   smartLists: true,
   smartypants: true,

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ hexo.config.marked = Object.assign({
   smartLists: true,
   smartypants: true,
   modifyAnchors: '',
-  autolink: true
+  autolink: true,
+  sanitizeUrl: false
 }, hexo.config.marked);
 
 hexo.extend.renderer.register('md', 'html', renderer, true);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -35,6 +35,22 @@ function anchorId(str, transformOption) {
 
 // Support AutoLink option
 Renderer.prototype.link = function(href, title, text) {
+  if (this.options.sanitizeUrl) {
+    let prot;
+
+    try {
+      prot = decodeURIComponent(unescape(href))
+          .replace(/[^\w:]/g, '')
+          .toLowerCase();
+    } catch (e) {
+      return '';
+    }
+
+    if (prot.startsWith('javascript:') || prot.startsWith('vbscript:') || prot.startsWith('data:')) {
+      return '';
+    }
+  }
+
   if (!this.options.autolink && href === text && title == null) {
     return href;
   }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -35,22 +35,6 @@ function anchorId(str, transformOption) {
 
 // Support AutoLink option
 Renderer.prototype.link = function(href, title, text) {
-  if (this.options.sanitize) {
-    let prot;
-
-    try {
-      prot = decodeURIComponent(unescape(href))
-          .replace(/[^\w:]/g, '')
-          .toLowerCase();
-    } catch (e) {
-      return '';
-    }
-
-    if (prot.startsWith('javascript:') || prot.startsWith('vbscript:') || prot.startsWith('data:')) {
-      return '';
-    }
-  }
-
   if (!this.options.autolink && href === text && title == null) {
     return href;
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "hexo-util": "^0.6.3",
-    "marked": "^0.6.2",
+    "marked": "^0.7.0",
     "strip-indent": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JS-MARKED-451341

`sanitize:` and `tables:` options have been deprecated.

`tables:` is now part of `gfm:`.

<details><summary>Changelog</summary>

* Security
  - Sanitize paragraph and text tokens #1504
  - Fix ReDOS for links with backticks (issue #1493) #1515

* Breaking Changes
  - Deprecate sanitize and sanitizer options #1504
  - Move fences to CommonMark #1511
  - Move tables to GFM #1511
  - Remove tables option #1511
  - Single backtick in link text needs to be escaped #1515

* Fixes
  - Fix parentheses around a link #1509
  - Fix headings (issue #1510) #1511

* Tests
  - Run tests with correct options #1511
</details>

Closes #101 