### PR TITLE
chore(deps): Update hexo-util to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "hexo-util": "^0.6.3",
+    "hexo-util": "1.0.0",
     "marked": "^0.7.0",
     "strip-indent": "^3.0.0"
   },


### PR DESCRIPTION
As part of https://github.com/hexojs/hexo/pull/3646.
@tomap has already published this change in hexo-renderer-marked@2.0.0rc1.