### PR TITLE
feat: prepend root to image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ marked:
   autolink: true
   sanitizeUrl: false
   headerIds: true
+  prependRoot: false
 ```
 
 - **gfm** - Enables [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown)
@@ -42,6 +43,13 @@ marked:
 - **autolink** - Enable autolink for URLs. E.g. `https://hexo.io` will become `<a href="https://hexo.io">https://hexo.io</a>`.
 - **sanitizeUrl** - Remove URLs that start with `javascript:`, `vbscript:` and `data:`.
 - **headerIds** - Insert header id, e.g. `<h1 id="value">text</h1>`. Useful for inserting anchor link to each paragraph with a heading.
+- **headerIds** - Insert header id, e.g. `<h1 id="value">text</h1>`. Useful for inserting anchor link to each paragraph with a heading.
+- **prependRoot** - Prepend root value to (internal) image path.
+  * Example `_config.yml`:
+  ``` yml
+  root: /blog/
+  ```
+  * `![text](/path/to/image.jpg)` becomes `<img src="/blog/path/to/image.jpg" alt="text">`
 
 ## Extras
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ hexo.config.marked = Object.assign({
   modifyAnchors: '',
   autolink: true,
   sanitizeUrl: false,
-  headerIds: true
+  headerIds: true,
+  // TODO: enable prependRoot by default in v3
+  prependRoot: false
 }, hexo.config.marked);
 
 hexo.extend.renderer.register('md', 'html', renderer, true);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,7 +2,7 @@
 
 const marked = require('marked');
 const stripIndent = require('strip-indent');
-const { stripHTML, highlight, slugize, encodeURL } = require('hexo-util');
+const { stripHTML, highlight, slugize, encodeURL, url_for } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
 const { parse } = require('url');
 
@@ -85,11 +85,9 @@ Renderer.prototype.paragraph = text => {
 
 // Prepend root to image path
 Renderer.prototype.image = function(href, title, text) {
-  const url_for = require('hexo-util').url_for.bind(this.options);
-
   if (!parse(href).hostname && !this.options.config.relative_link
     && this.options.prependRoot) {
-    href = url_for(href);
+    href = url_for.call(this.options, href);
   }
 
   return `<img src="${encodeURL(href)}" alt="${text}">`;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,8 +2,9 @@
 
 const marked = require('marked');
 const stripIndent = require('strip-indent');
-const { stripHTML, highlight, slugize } = require('hexo-util');
+const { stripHTML, highlight, slugize, encodeURL } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
+const { parse } = require('url');
 
 function Renderer() {
   MarkedRenderer.apply(this);
@@ -82,6 +83,23 @@ Renderer.prototype.paragraph = text => {
   return `<p>${text}</p>\n`;
 };
 
+// Prepend root to image path
+Renderer.prototype.image = function(href, title, text) {
+  const url_for = require('hexo/lib/plugins/helper/url_for').bind(this);
+  Object.assign(this, {
+    config: {
+      root: this.options.root,
+      relative_link: this.options.relative_link
+    }
+  });
+
+  if (!parse(href).hostname && this.options.prependRoot) {
+    href = url_for(href);
+  }
+
+  return `<img src="${encodeURL(href)}" alt="${text}">`;
+};
+
 marked.setOptions({
   langPrefix: '',
   highlight(code, lang) {
@@ -96,5 +114,5 @@ marked.setOptions({
 module.exports = function(data, options) {
   return marked(data.text, Object.assign({
     renderer: new Renderer()
-  }, this.config.marked, options));
+  }, this.config.marked, options, this.config));
 };

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -85,13 +85,7 @@ Renderer.prototype.paragraph = text => {
 
 // Prepend root to image path
 Renderer.prototype.image = function(href, title, text) {
-  const url_for = require('hexo/lib/plugins/helper/url_for').bind(this);
-  Object.assign(this, {
-    config: {
-      root: this.options.root,
-      relative_link: this.options.relative_link
-    }
-  });
+  const url_for = require('hexo/lib/plugins/helper/url_for').bind(this.options);
 
   if (!parse(href).hostname && this.options.prependRoot) {
     href = url_for(href);
@@ -112,7 +106,14 @@ marked.setOptions({
 });
 
 module.exports = function(data, options) {
+  const url_forCfg = Object.assign({}, {
+    config: {
+      root: this.config.root,
+      relative_link: this.config.relative_link
+    }
+  });
+
   return marked(data.text, Object.assign({
     renderer: new Renderer()
-  }, this.config.marked, options, this.config));
+  }, this.config.marked, options, url_forCfg));
 };

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -85,7 +85,7 @@ Renderer.prototype.paragraph = text => {
 
 // Prepend root to image path
 Renderer.prototype.image = function(href, title, text) {
-  const url_for = require('hexo/lib/plugins/helper/url_for').bind(this.options);
+  const url_for = require('hexo-util').url_for.bind(this.options);
 
   if (!parse(href).hostname && !this.options.config.relative_link
     && this.options.prependRoot) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -87,7 +87,8 @@ Renderer.prototype.paragraph = text => {
 Renderer.prototype.image = function(href, title, text) {
   const url_for = require('hexo/lib/plugins/helper/url_for').bind(this.options);
 
-  if (!parse(href).hostname && this.options.prependRoot) {
+  if (!parse(href).hostname && !this.options.config.relative_link
+    && this.options.prependRoot) {
     href = url_for(href);
   }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "hexo": "^3.9.0",
-    "hexo-util": "^1.0.1",
+    "hexo-util": "^1.1.0",
     "marked": "^0.7.0",
     "strip-indent": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "hexo": "^3.9.0",
     "hexo-util": "^1.0.1",
     "marked": "^0.7.0",
     "strip-indent": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "hexo": "^3.9.0",
-    "hexo-util": "^1.2.0",
+    "hexo-util": "^1.3.0",
     "marked": "^0.7.0",
     "strip-indent": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "hexo": "^3.9.0",
-    "hexo-util": "^1.1.0",
+    "hexo-util": "^1.2.0",
     "marked": "^0.7.0",
     "strip-indent": "^3.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -211,6 +211,16 @@ describe('Marked renderer', () => {
     };
 
     it('should not modify image path with default option', () => {
+      const r = renderer.bind(ctx);
+      const result = r({text: body});
+
+      result.should.eql([
+        '<p><img src="/bar/baz.jpg" alt="">',
+        '<img src="/aaa/bbb.jpg" alt="foo"></p>\n'
+      ].join('\n'));
+    });
+
+    it('should not modify image path when enable relative_link', () => {
       ctx.config.relative_link = true;
       const r = renderer.bind(ctx);
       const result = r({text: body});
@@ -219,6 +229,7 @@ describe('Marked renderer', () => {
         '<p><img src="/bar/baz.jpg" alt="">',
         '<img src="/aaa/bbb.jpg" alt="foo"></p>\n'
       ].join('\n'));
+
       ctx.config.relative_link = false;
     });
 
@@ -231,6 +242,7 @@ describe('Marked renderer', () => {
         '<p><img src="/blog/bar/baz.jpg" alt="">',
         '<img src="/blog/aaa/bbb.jpg" alt="foo"></p>\n'
       ].join('\n'));
+      ctx.config.marked.prependRoot = false;
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -191,4 +191,43 @@ describe('Marked renderer', () => {
       ].join('\n'));
     });
   });
+
+  describe('prependRoot option tests', () => {
+    const body = [
+      '![](/bar/baz.jpg)',
+      '![foo](/aaa/bbb.jpg)'
+    ].join('\n');
+
+    const renderer = require('../lib/renderer');
+
+    const ctx = {
+      config: {
+        marked: {
+          prependRoot: false
+        },
+        root: '/blog/'
+      }
+    };
+
+    it('should not modify image path with default option', () => {
+      const r = renderer.bind(ctx);
+      const result = r({text: body});
+
+      result.should.eql([
+        '<p><img src="/bar/baz.jpg" alt="">',
+        '<img src="/aaa/bbb.jpg" alt="foo"></p>\n'
+      ].join('\n'));
+    });
+
+    it('should prepend image path with root', () => {
+      ctx.config.marked.prependRoot = true;
+      const r = renderer.bind(ctx);
+      const result = r({text: body});
+
+      result.should.eql([
+        '<p><img src="/blog/bar/baz.jpg" alt="">',
+        '<img src="/blog/aaa/bbb.jpg" alt="foo"></p>\n'
+      ].join('\n'));
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -245,4 +245,21 @@ describe('Marked renderer', () => {
       ctx.config.marked.prependRoot = false;
     });
   });
+
+  it('should encode image url', () => {
+    const body = [
+      '![](/foo/bár.jpg)',
+      '![](http://fóo.com/bar.jpg)'
+    ].join('\n');
+
+    const renderer = require('../lib/renderer');
+    const r = renderer.bind(ctx);
+
+    const result = r({text: body});
+
+    result.should.eql([
+      '<p><img src="/foo/b%C3%A1r.jpg" alt="">',
+      '<img src="http://xn--fo-5ja.com/bar.jpg" alt=""></p>\n'
+    ].join('\n'));
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -205,11 +205,13 @@ describe('Marked renderer', () => {
         marked: {
           prependRoot: false
         },
-        root: '/blog/'
+        root: '/blog/',
+        relative_link: false
       }
     };
 
     it('should not modify image path with default option', () => {
+      ctx.config.relative_link = true;
       const r = renderer.bind(ctx);
       const result = r({text: body});
 
@@ -217,6 +219,7 @@ describe('Marked renderer', () => {
         '<p><img src="/bar/baz.jpg" alt="">',
         '<img src="/aaa/bbb.jpg" alt="foo"></p>\n'
       ].join('\n'));
+      ctx.config.relative_link = false;
     });
 
     it('should prepend image path with root', () => {


### PR DESCRIPTION
encodeURL is added in hexo-util [1.1.0](https://github.com/hexojs/hexo-util/releases/tag/1.1.0).

url_for is added in hexo-util [1.2.0](https://github.com/hexojs/hexo-util/releases/tag/1.2.0).

This feature can be enabled through `prependRoot` option, which is disabled by default.