### PR TITLE
feat(link): add external_link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ marked:
   sanitizeUrl: false
   headerIds: true
   prependRoot: false
+  external_link:
+    enable: false
+    exclude: []
 ```
 
 - **gfm** - Enables [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown)
@@ -50,6 +53,10 @@ marked:
   root: /blog/
   ```
   * `![text](/path/to/image.jpg)` becomes `<img src="/blog/path/to/image.jpg" alt="text">`
+- **external_link**
+  * **enable** - Open external links in a new tab.
+  * **exclude** - Exclude hostname. Specify subdomain when applicable, including `www`.
+  * Example: `[foo](http://bar.com)` becomes `<a href="http://bar.com" target="_blank" rel="noopener">foo</a>`
 
 ## Extras
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ hexo.config.marked = Object.assign({
   sanitizeUrl: false,
   headerIds: true,
   // TODO: enable prependRoot by default in v3
-  prependRoot: false
+  prependRoot: false,
+  external_link: {
+    enable: false,
+    exclude: []
+  }
 }, hexo.config.marked);
 
 hexo.extend.renderer.register('md', 'html', renderer, true);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -5,31 +5,26 @@ const marked = require('marked');
 const stripIndent = require('strip-indent');
 const { encodeURL, highlight, slugize, stripHTML, url_for } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
-const { URL } = require('url');
-
-const urlObj = (str) => {
-  try {
-    return new URL(str);
-  } catch (err) {
-    return str;
-  }
-};
+const { parse, URL } = require('url');
 
 /**
  * Check whether the link is external
  * @param {String} url The url to check
- * @param {Object} config The site config
+ * @param {Object} siteCfg The site config
+ * @param {String|array} exclude Domain(s) to be excluded
  * @returns {Boolean} True if the link is an internal link or having the same host with config.url
  */
 const isExternal = (url, siteCfg, exclude) => {
-  const data = urlObj(url);
-  const host = typeof data === 'object' ? data.hostname : '';
-  const sitehost = typeof urlObj(siteCfg.url) === 'object' ? urlObj(siteCfg.url).hostname
-    : siteCfg.url;
+  const sitehost = parse(siteCfg.url).hostname || siteCfg.url;
+  if (!sitehost) return false;
 
-  if (!sitehost || typeof data === 'string') return false;
+  // handle relative url
+  const data = new URL(url, `http://${sitehost}`);
+
+  // handle mailto: javascript: vbscript: and so on
   if (data.origin === 'null') return false;
 
+  const host = data.hostname;
 
   if (exclude) {
     exclude = Array.isArray(exclude) ? exclude : [exclude];
@@ -124,7 +119,7 @@ Renderer.prototype.paragraph = text => {
 Renderer.prototype.image = function(href, title, text) {
   const { options } = this;
 
-  if (!isExternal(href, options.config) && !options.config.relative_link
+  if (!parse(href).hostname && !options.config.relative_link
     && options.prependRoot) {
     href = url_for.call(options, href);
   }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -5,7 +5,7 @@ const marked = require('marked');
 const stripIndent = require('strip-indent');
 const { encodeURL, highlight, slugize, stripHTML, url_for } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
-const { parse, URL } = require('url');
+const { URL } = require('url');
 
 const urlObj = (str) => {
   try {
@@ -21,9 +21,7 @@ const urlObj = (str) => {
  * @param {Object} config The site config
  * @returns {Boolean} True if the link is an internal link or having the same host with config.url
  */
-const isExternal = (url, siteCfg, excludeCfg) => {
-  const exclude = Array.isArray(excludeCfg.exclude) ? excludeCfg.exclude
-    : [excludeCfg.exclude];
+const isExternal = (url, siteCfg, exclude) => {
   const data = urlObj(url);
   const host = typeof data === 'object' ? data.hostname : '';
   const sitehost = typeof urlObj(siteCfg.url) === 'object' ? urlObj(siteCfg.url).hostname
@@ -32,7 +30,10 @@ const isExternal = (url, siteCfg, excludeCfg) => {
   if (!sitehost || typeof data === 'string') return false;
   if (data.origin === 'null') return false;
 
-  if (exclude && exclude.length) {
+
+  if (exclude) {
+    exclude = Array.isArray(exclude) ? exclude : [exclude];
+
     for (const i of exclude) {
       if (host === i) return false;
     }
@@ -94,7 +95,7 @@ Renderer.prototype.link = function(href, title, text) {
   }
 
   if (external_link) {
-    if (external_link.enable && isExternal(href, options.config, external_link)) {
+    if (external_link.enable && isExternal(href, options.config, external_link.exclude)) {
       out += ' target="_blank" rel="noopener"';
     }
   }
@@ -118,10 +119,11 @@ Renderer.prototype.paragraph = text => {
 
 // Prepend root to image path
 Renderer.prototype.image = function(href, title, text) {
-  // refactor parse to isExternal
-  if (!parse(href).hostname && !this.options.config.relative_link
-    && this.options.prependRoot) {
-    href = url_for.call(this.options, href);
+  const { options } = this;
+
+  if (!isExternal(href, options.config) && !options.config.relative_link
+    && options.prependRoot) {
+    href = url_for.call(options, href);
   }
 
   return `<img src="${encodeURL(href)}" alt="${text}">`;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -3,9 +3,45 @@
 const { inherits } = require('util');
 const marked = require('marked');
 const stripIndent = require('strip-indent');
-const { stripHTML, highlight, slugize, encodeURL, url_for } = require('hexo-util');
+const { encodeURL, highlight, slugize, stripHTML, url_for } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
-const { parse } = require('url');
+const { parse, URL } = require('url');
+
+const urlObj = (str) => {
+  try {
+    return new URL(str);
+  } catch (err) {
+    return str;
+  }
+};
+
+/**
+ * Check whether the link is external
+ * @param {String} url The url to check
+ * @param {Object} config The site config
+ * @returns {Boolean} True if the link is an internal link or having the same host with config.url
+ */
+const isExternal = (url, siteCfg, excludeCfg) => {
+  const exclude = Array.isArray(excludeCfg.exclude) ? excludeCfg.exclude
+    : [excludeCfg.exclude];
+  const data = urlObj(url);
+  const host = typeof data === 'object' ? data.hostname : '';
+  const sitehost = typeof urlObj(siteCfg.url) === 'object' ? urlObj(siteCfg.url).hostname
+    : siteCfg.url;
+
+  if (!sitehost || typeof data === 'string') return false;
+  if (data.origin === 'null') return false;
+
+  if (exclude && exclude.length) {
+    for (const i of exclude) {
+      if (host === i) return false;
+    }
+  }
+
+  if (host !== sitehost) return true;
+
+  return false;
+};
 
 function Renderer() {
   MarkedRenderer.apply(this);
@@ -47,7 +83,7 @@ Renderer.prototype.link = function(href, title, text) {
     }
   }
 
-  if (!this.options.autolink && href === text && title == null) {
+  if (!options.autolink && href === text && title == null) {
     return href;
   }
 
@@ -55,6 +91,12 @@ Renderer.prototype.link = function(href, title, text) {
 
   if (title) {
     out += ` title="${title}"`;
+  }
+
+  if (external_link) {
+    if (external_link.enable && isExternal(href, options.config, external_link)) {
+      out += ' target="_blank" rel="noopener"';
+    }
   }
 
   out += `>${text}</a>`;
@@ -76,6 +118,7 @@ Renderer.prototype.paragraph = text => {
 
 // Prepend root to image path
 Renderer.prototype.image = function(href, title, text) {
+  // refactor parse to isExternal
   if (!parse(href).hostname && !this.options.config.relative_link
     && this.options.prependRoot) {
     href = url_for.call(this.options, href);
@@ -96,8 +139,9 @@ marked.setOptions({
 });
 
 module.exports = function(data, options) {
-  const url_forCfg = Object.assign({}, {
+  const siteCfg = Object.assign({}, {
     config: {
+      url: this.config.url,
       root: this.config.root,
       relative_link: this.config.relative_link
     }
@@ -105,5 +149,5 @@ module.exports = function(data, options) {
 
   return marked(data.text, Object.assign({
     renderer: new Renderer()
-  }, this.config.marked, options, url_forCfg));
+  }, this.config.marked, options, siteCfg));
 };

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -78,7 +78,10 @@ function anchorId(str, transformOption) {
 
 // Support AutoLink option
 Renderer.prototype.link = function(href, title, text) {
-  if (this.options.sanitizeUrl) {
+  const { options } = this;
+  const { external_link } = options;
+
+  if (options.sanitizeUrl) {
     if (href.startsWith('javascript:') || href.startsWith('vbscript:') || href.startsWith('data:')) {
       href = '';
     }

--- a/test/index.js
+++ b/test/index.js
@@ -278,19 +278,19 @@ describe('Marked renderer', () => {
     };
 
     it('disable', () => {
-      const body = '[foo](http://bar.com)';
+      const body = '[foo](http://bar.com/)';
 
       const r = renderer.bind(ctx);
       const result = r({text: body});
 
-      result.should.eql('<p><a href="http://bar.com">foo</a></p>\n');
+      result.should.eql('<p><a href="http://bar.com/">foo</a></p>\n');
     });
 
     it('enable', () => {
       ctx.config.marked.external_link.enable = true;
       const body = [
-        '[foo](http://bar.com)',
-        '[text](http://example.com)',
+        '[foo](http://bar.com/)',
+        '[text](http://example.com/)',
         '[baz](/foo/bar)'
       ].join('\n');
 
@@ -298,8 +298,8 @@ describe('Marked renderer', () => {
       const result = r({text: body});
 
       result.should.eql([
-        '<p><a href="http://bar.com" target="_blank" rel="noopener">foo</a>',
-        '<a href="http://example.com">text</a>',
+        '<p><a href="http://bar.com/" target="_blank" rel="noopener">foo</a>',
+        '<a href="http://example.com/">text</a>',
         '<a href="/foo/bar">baz</a></p>\n'
       ].join('\n'));
     });
@@ -307,36 +307,36 @@ describe('Marked renderer', () => {
     it('exclude - string', () => {
       ctx.config.marked.external_link.exclude = 'bar.com';
       const body = [
-        '[foo](http://foo.com)',
-        '[bar](http://bar.com)',
-        '[baz](http://baz.com)'
+        '[foo](http://foo.com/)',
+        '[bar](http://bar.com/)',
+        '[baz](http://baz.com/)'
       ].join('\n');
 
       const r = renderer.bind(ctx);
       const result = r({text: body});
 
       result.should.eql([
-        '<p><a href="http://foo.com" target="_blank" rel="noopener">foo</a>',
-        '<a href="http://bar.com">bar</a>',
-        '<a href="http://baz.com" target="_blank" rel="noopener">baz</a></p>\n'
+        '<p><a href="http://foo.com/" target="_blank" rel="noopener">foo</a>',
+        '<a href="http://bar.com/">bar</a>',
+        '<a href="http://baz.com/" target="_blank" rel="noopener">baz</a></p>\n'
       ].join('\n'));
     });
 
     it('exclude - array', () => {
       ctx.config.marked.external_link.exclude = ['bar.com', 'baz.com'];
       const body = [
-        '[foo](http://foo.com)',
-        '[bar](http://bar.com)',
-        '[baz](http://baz.com)'
+        '[foo](http://foo.com/)',
+        '[bar](http://bar.com/)',
+        '[baz](http://baz.com/)'
       ].join('\n');
 
       const r = renderer.bind(ctx);
       const result = r({text: body});
 
       result.should.eql([
-        '<p><a href="http://foo.com" target="_blank" rel="noopener">foo</a>',
-        '<a href="http://bar.com">bar</a>',
-        '<a href="http://baz.com">baz</a></p>\n'
+        '<p><a href="http://foo.com/" target="_blank" rel="noopener">foo</a>',
+        '<a href="http://bar.com/">bar</a>',
+        '<a href="http://baz.com/">baz</a></p>\n'
       ].join('\n'));
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -263,6 +263,84 @@ describe('Marked renderer', () => {
     });
   });
 
+  describe('external_link', () => {
+    const renderer = require('../lib/renderer');
+
+    const ctx = {
+      config: {
+        marked: {
+          external_link: {
+            enable: false
+          }
+        },
+        url: 'http://example.com'
+      }
+    };
+
+    it('disable', () => {
+      const body = '[foo](http://bar.com)';
+
+      const r = renderer.bind(ctx);
+      const result = r({text: body});
+
+      result.should.eql('<p><a href="http://bar.com">foo</a></p>\n');
+    });
+
+    it('enable', () => {
+      ctx.config.marked.external_link.enable = true;
+      const body = [
+        '[foo](http://bar.com)',
+        '[text](http://example.com)',
+        '[baz](/foo/bar)'
+      ].join('\n');
+
+      const r = renderer.bind(ctx);
+      const result = r({text: body});
+
+      result.should.eql([
+        '<p><a href="http://bar.com" target="_blank" rel="noopener">foo</a>',
+        '<a href="http://example.com">text</a>',
+        '<a href="/foo/bar">baz</a></p>\n'
+      ].join('\n'));
+    });
+
+    it('exclude - string', () => {
+      ctx.config.marked.external_link.exclude = 'bar.com';
+      const body = [
+        '[foo](http://foo.com)',
+        '[bar](http://bar.com)',
+        '[baz](http://baz.com)'
+      ].join('\n');
+
+      const r = renderer.bind(ctx);
+      const result = r({text: body});
+
+      result.should.eql([
+        '<p><a href="http://foo.com" target="_blank" rel="noopener">foo</a>',
+        '<a href="http://bar.com">bar</a>',
+        '<a href="http://baz.com" target="_blank" rel="noopener">baz</a></p>\n'
+      ].join('\n'));
+    });
+
+    it('exclude - array', () => {
+      ctx.config.marked.external_link.exclude = ['bar.com', 'baz.com'];
+      const body = [
+        '[foo](http://foo.com)',
+        '[bar](http://bar.com)',
+        '[baz](http://baz.com)'
+      ].join('\n');
+
+      const r = renderer.bind(ctx);
+      const result = r({text: body});
+
+      result.should.eql([
+        '<p><a href="http://foo.com" target="_blank" rel="noopener">foo</a>',
+        '<a href="http://bar.com">bar</a>',
+        '<a href="http://baz.com">baz</a></p>\n'
+      ].join('\n'));
+    });
+  });
+
   it('should encode image url', () => {
     const urlA = '/foo/bár.jpg';
     const urlB = 'http://fóo.com/bar.jpg';


### PR DESCRIPTION
This feature is introduced due to perf cost of the `external_link` [filter](https://github.com/hexojs/hexo/blob/master/lib/plugins/filter/after_render/external_link.js). When use in renderer, it can be applied directly to links, instead of a filter which has to first parse the whole site content to look for links.

To take advantage of the perf improvement, `external_link:` of the site config needs to be disabled.

Configuration:

``` yml
external_link:
  enable: false

marked:
  external_link:
    enable: true
```

Some notes:

1. This feature is only applicable to `[]()` markdown syntax, not raw `<a>`.
2. This is not a duplicate hexo's [`external_link`](https://hexo.io/docs/configuration#Writing) as that works on `<a>` element, not markdown.
    - hexo's `external_link` applies to every `<a>` regardless the source is raw `<a>` or `[]()` (that is later rendered as `<a>`)
    - this also means the plugin uses its own `external_link` config, separate from the [`external_link`](https://hexo.io/docs/configuration#Writing) site config.
3. This feature applies to post and page, but not theme layout (see point 1).
4. This should be compatible with hexo's `external_link`, meaning both hexo and this renderer's `external_link` can be enabled at the same time. hexo's `external_link` does avoid [duplicate attributes](https://github.com/hexojs/hexo/blob/a088edec0a3ba3dc1eb4f1b6d71c0528e77bf06d/test/scripts/filters/external_link.js#L59).
5. [`isExternalLink`](https://github.com/hexojs/hexo-util/tree/9dfc53d0696a2d7e362a6ed69c0c4b381c52721b#isexternallinkurl) could not be used here as that utility uses site config (i.e. `external_link` site config), whereas this plugin has its own `external_link` config.

Ref: https://github.com/hexojs/hexo/issues/3833#issuecomment-551043290