### PR TITLE
feat: support title attribute in image element

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -124,7 +124,14 @@ Renderer.prototype.image = function(href, title, text) {
     href = url_for.call(options, href);
   }
 
-  return `<img src="${encodeURL(href)}" alt="${text}">`;
+  let out = `<img src="${encodeURL(href)}"`;
+
+  if (text) out += ` alt="${text}"`;
+  if (title) out += ` title="${title}"`;
+
+  out += '>';
+
+  return out;
 };
 
 marked.setOptions({

--- a/test/index.js
+++ b/test/index.js
@@ -276,7 +276,7 @@ describe('Marked renderer', () => {
       const result = r({text: body});
 
       result.should.eql([
-        '<p><img src="/bar/baz.jpg" alt="">',
+        '<p><img src="/bar/baz.jpg">',
         '<img src="/aaa/bbb.jpg" alt="foo"></p>\n'
       ].join('\n'));
     });
@@ -287,7 +287,7 @@ describe('Marked renderer', () => {
       const result = r({text: body});
 
       result.should.eql([
-        '<p><img src="/bar/baz.jpg" alt="">',
+        '<p><img src="/bar/baz.jpg">',
         '<img src="/aaa/bbb.jpg" alt="foo"></p>\n'
       ].join('\n'));
 
@@ -300,7 +300,7 @@ describe('Marked renderer', () => {
       const result = r({text: body});
 
       result.should.eql([
-        '<p><img src="/blog/bar/baz.jpg" alt="">',
+        '<p><img src="/blog/bar/baz.jpg">',
         '<img src="/blog/aaa/bbb.jpg" alt="foo"></p>\n'
       ].join('\n'));
       ctx.config.marked.prependRoot = false;
@@ -400,8 +400,27 @@ describe('Marked renderer', () => {
     const result = r({text: body});
 
     result.should.eql([
-      `<p><img src="${encodeURL(urlA)}" alt="">`,
-      `<img src="${encodeURL(urlB)}" alt=""></p>\n`
+      `<p><img src="${encodeURL(urlA)}">`,
+      `<img src="${encodeURL(urlB)}"></p>\n`
+    ].join('\n'));
+  });
+
+  it('should include image caption & title', () => {
+    const body = [
+      '![caption](http://foo.com/a.jpg)',
+      '![caption](http://bar.com/b.jpg "a-title")',
+      '![a"b](http://bar.com/b.jpg "c>d")'
+    ].join('\n');
+
+    const renderer = require('../lib/renderer');
+    const r = renderer.bind(ctx);
+
+    const result = r({text: body});
+
+    result.should.eql([
+      '<p><img src="http://foo.com/a.jpg" alt="caption">',
+      '<img src="http://bar.com/b.jpg" alt="caption" title="a-title">',
+      '<img src="http://bar.com/b.jpg" alt="a&quot;b" title="c&gt;d"></p>\n'
     ].join('\n'));
   });
 });


### PR DESCRIPTION
https://www.stephencharlesweiss.com/2019-08-22/markdown-images-alt-text-and-title/

Noticed when testing https://github.com/hexojs/hexo/issues/3879

marked escapes values of `alt` and `title` by default.