### PR TITLE
refactor: remove marked.setOptions.highlight

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,8 +2,7 @@
 
 const { promisify } = require('util');
 const marked = promisify(require('marked'));
-const stripIndent = require('strip-indent');
-const { encodeURL, highlight, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
+const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
 const { parse } = require('url');
 
@@ -102,14 +101,7 @@ class Renderer extends MarkedRenderer {
 }
 
 marked.setOptions({
-  langPrefix: '',
-  highlight(code, lang) {
-    return highlight(stripIndent(code), {
-      lang,
-      gutter: false,
-      wrap: false
-    });
-  }
+  langPrefix: ''
 });
 
 module.exports = async function(data, options) {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "hexo-util": "^1.6.1",
-    "marked": "^0.8.0",
-    "strip-indent": "^3.0.0"
+    "marked": "^0.8.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('chai').should();
-const { highlight, encodeURL } = require('hexo-util');
+const { encodeURL, escapeHTML } = require('hexo-util');
 const Hexo = require('hexo');
 
 describe('Marked renderer', () => {
@@ -33,7 +33,7 @@ describe('Marked renderer', () => {
 
     result.should.eql([
       '<h1 id="Hello-world"><a href="#Hello-world" class="headerlink" title="Hello world"></a>Hello world</h1>',
-      '<pre><code>' + highlight(code, {gutter: false, wrap: false}) + '</code></pre>',
+      '<pre><code>' + escapeHTML(code) + '</code></pre>',
       '<h2 id="Hello-world-1"><a href="#Hello-world-1" class="headerlink" title="Hello world"></a>Hello world</h2>',
       '<p>hello</p>'
     ].join('') + '\n');


### PR DESCRIPTION
This PR makes the code blocks result consistent by removing `marked.setOptions.highlight`.

More info can be found here: https://github.com/hexojs/hexo/issues/4010#issuecomment-568906344

> #### `config.highlight.enable: true`
> By default `hljs` is disabled and `wrap` is enabled. Hexo will render something likes:
> 
> ```
> <figure class="highlight sh">
>   <table>
>     ...
>   </table>
> </figure>
> ```
> 
> #### `config.highlight.enable: false` with `hexo-renderer-marked`
> Since highlight has been disabled, the `before_post_render` filter will do nothing and leave everything to helpers (powered by nunjucks) and marked (from hexo-renderer-marked).
> 
> `code()` helper [is designed](https://github.com/hexojs/hexo/blob/8fae1a6a98d9fd6ffb6f07ab549a4cf723d8b032/lib/plugins/tag/code.js#L136-L139) to leave everything it should be without applying any `highlight.js` specific options, so it will render something like:
> 
> ```
> <pre>
>   <code>
>     ...
>   </code>
> </pre>
> ```
> 
> But for code block wrapped in `backticks`, it will be rendered by `hexo-rendered-marked`. And `hexo-renderer-marked` will call `hexo-util.highlight` with only `str` and `lang` option is given. So it will be rendered to:
> 
> ```
> <pre>
>   <code class="bash">
>     ...
>   </code>
> </pre>
> ```
> 
> #### `config.highlight.enable: false` with `hexo-rendered-markdown-it`
> For `code()` helper, the result is pretty much the same as with `hexo-renderer-marked` (just as I said, helpers will not be processed by markdown renderer).
> 
> For code block wrapped in `backticks`, since `markdown-it` itself has no `marked.setOptions.highlight` like `marked`, so the result is the same:
> 
> ```
> <pre>
>   <code>
>     ...
>   </code>
> </pre>
> ```

