### PR TITLE
ci(travis): drop Node 8 and add Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
   npm: true
 
 node_js:
-  - "8"
   - "10"
   - "12"
   - "13"
+  - "14"
 
 script:
   - npm run eslint


### PR DESCRIPTION
Node 13 is retained for now for debugging (ref https://github.com/hexojs/hexo/issues/4260), to be deprecated in [June 2020](https://github.com/nodejs/Release#release-schedule).