### PR TITLE
feat(image): postAsset to prepend post's relative path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - windows
+
 language: node_js
 
 cache:
@@ -9,7 +13,9 @@ node_js:
   - "14"
 
 script:
-  - npm run eslint
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
+      npm run eslint;
+    fi
   - npm run test-cov
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ marked:
   * "image.jpg" is located at "/2020/01/02/foo/image.jpg", which is a post asset of "/2020/01/02/foo/".
   * `![](image.jpg)` becomes `<img src="/2020/01/02/foo/image.jpg">`
   * Requires `prependRoot:` to be enabled.
-  * This may reduce performance due to additional processing.
 - **external_link**
   * **enable** - Open external links in a new tab.
   * **exclude** - Exclude hostname. Specify subdomain when applicable, including `www`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ marked:
   headerIds: true
   lazyload: false
   prependRoot: false
+  postAsset: false
   external_link:
     enable: false
     exclude: []
@@ -55,6 +56,10 @@ marked:
   root: /blog/
   ```
   * `![text](/path/to/image.jpg)` becomes `<img src="/blog/path/to/image.jpg" alt="text">`
+- **postAsset** - Resolve post asset's image path to relative path and prepend root valuewhen [`post_asset_folder`](https://hexo.io/docs/asset-folders) is enabled.
+  * "image.jpg" is located at "/2020/01/02/foo/image.jpg", which is a post asset of "/2020/01/02/foo/".
+  * `![](image.jpg)` becomes `<img src="/2020/01/02/foo/image.jpg">`
+  * Requires `prependRoot:` to be enabled.
 - **external_link**
   * **enable** - Open external links in a new tab.
   * **exclude** - Exclude hostname. Specify subdomain when applicable, including `www`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ marked:
   root: /blog/
   ```
   * `![text](/path/to/image.jpg)` becomes `<img src="/blog/path/to/image.jpg" alt="text">`
-- **postAsset** - Resolve post asset's image path to relative path and prepend root valuewhen [`post_asset_folder`](https://hexo.io/docs/asset-folders) is enabled.
+- **postAsset** - Resolve post asset's image path to relative path and prepend root value when [`post_asset_folder`](https://hexo.io/docs/asset-folders) is enabled.
   * "image.jpg" is located at "/2020/01/02/foo/image.jpg", which is a post asset of "/2020/01/02/foo/".
   * `![](image.jpg)` becomes `<img src="/2020/01/02/foo/image.jpg">`
   * Requires `prependRoot:` to be enabled.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ marked:
   * "image.jpg" is located at "/2020/01/02/foo/image.jpg", which is a post asset of "/2020/01/02/foo/".
   * `![](image.jpg)` becomes `<img src="/2020/01/02/foo/image.jpg">`
   * Requires `prependRoot:` to be enabled.
+  * This may reduce performance due to additional processing.
 - **external_link**
   * **enable** - Open external links in a new tab.
   * **exclude** - Exclude hostname. Specify subdomain when applicable, including `www`.

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -92,7 +92,6 @@ class Renderer extends MarkedRenderer {
   image(href, title, text) {
     const { relative_link } = hexo.config;
     const { options } = this;
-    const { relative_link } = hexo.config;
     const { lazyload, prependRoot, postId } = options;
     const { hostname } = parse(href);
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -4,6 +4,7 @@ const marked = require('marked');
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
 const { parse } = require('url');
+const { join, relative } = require('path').posix;
 
 const anchorId = (str, transformOption) => {
   return slugize(str.trim(), {transform: transformOption});
@@ -87,6 +88,7 @@ class Renderer extends MarkedRenderer {
 
     if (!parse(href).hostname && !options.config.relative_link
       && options.prependRoot) {
+      if (options.path) href = join(options.path, href);
       href = url_for.call(options, href);
     }
 
@@ -109,7 +111,8 @@ module.exports = function(data, options) {
     config: {
       url: this.config.url,
       root: this.config.root,
-      relative_link: this.config.relative_link
+      relative_link: this.config.relative_link,
+      post_asset_folder: this.config.post_asset_folder
     }
   });
 
@@ -117,7 +120,15 @@ module.exports = function(data, options) {
   const renderer = new Renderer();
   this.execFilterSync('marked:renderer', renderer, {context: this});
 
+  let path = '';
+  if (data.path && this.config.post_asset_folder && this.config.marked.prependRoot && this.config.marked.postAsset) {
+    const Post = this.model('Post');
+    const source = relative(this.source_dir, data.path);
+    const post = Post.findOne({ source });
+    path = post ? post.path : '';
+  }
+
   return marked(data.text, Object.assign({
     renderer
-  }, this.config.marked, options, siteCfg));
+  }, this.config.marked, options, siteCfg, { path }));
 };

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -3,7 +3,6 @@
 const marked = require('marked');
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
-const { sep } = require('path');
 
 const anchorId = (str, transformOption) => {
   return slugize(str.trim(), {transform: transformOption});
@@ -91,14 +90,15 @@ class Renderer extends MarkedRenderer {
   image(href, title, text) {
     const { hexo, options } = this;
     const { relative_link } = hexo.config;
-    const { lazyload, prependRoot, postId } = options;
+    const { lazyload, prependRoot, postPath } = options;
 
     if (!/^(#|\/\/|http(s)?:)/.test(href) && !relative_link && prependRoot) {
-      if (!/^(\/|\\)/.test(href) && postId) {
+      if (!href.startsWith('/') && !href.startsWith('\\') && postPath) {
         const PostAsset = hexo.model('PostAsset');
-        // slug requires platform-specific path
-        const asset = PostAsset.findOne({ post: postId, slug: href.replace(/\/|\\/g, sep) });
-        if (asset) href = encodeURL(('/' + asset.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
+        // findById requires forward slash
+        const asset = PostAsset.findById(postPath + href.replace(/\\/g, '/'));
+        // asset.path is backward slash in Windows
+        if (asset) href = asset.path.replace(/\\/g, '/');
       }
       href = url_for.call(hexo, href);
     }
@@ -118,7 +118,7 @@ marked.setOptions({
 });
 
 module.exports = function(data, options) {
-  const { post_asset_folder, marked: markedCfg } = this.config;
+  const { post_asset_folder, marked: markedCfg, source_dir } = this.config;
   const { prependRoot, postAsset } = markedCfg;
   const { path, text } = data;
 
@@ -126,16 +126,16 @@ module.exports = function(data, options) {
   const renderer = new Renderer(this);
   this.execFilterSync('marked:renderer', renderer, {context: this});
 
-  let postId = '';
+  let postPath = '';
   if (path && post_asset_folder && prependRoot && postAsset) {
     const Post = this.model('Post');
     // Windows compatibility, Post.findOne() requires forward slash
-    const source = path.replace(this.source_dir, '').replace('\\', '/');
+    const source = path.substring(this.source_dir.length).replace(/\\/g, '/');
     const post = Post.findOne({ source });
-    postId = post ? post._id : '';
+    postPath = post ? source_dir + '/_posts/' + post.slug + '/' : '';
   }
 
   return marked(text, Object.assign({
     renderer
-  }, markedCfg, options, { postId }));
+  }, markedCfg, options, { postPath }));
 };

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -4,16 +4,16 @@ const marked = require('marked');
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
 const { sep } = require('path');
-let hexo;
 
 const anchorId = (str, transformOption) => {
   return slugize(str.trim(), {transform: transformOption});
 };
 
 class Renderer extends MarkedRenderer {
-  constructor() {
+  constructor(hexo) {
     super();
     this._headingId = {};
+    this.hexo = hexo;
   }
 
   // Add id attribute to headings
@@ -43,7 +43,7 @@ class Renderer extends MarkedRenderer {
   // Support AutoLink option
   link(href, title, text) {
     const { autolink, external_link, sanitizeUrl } = this.options;
-    const { url: urlCfg } = hexo.config;
+    const { url: urlCfg } = this.hexo.config;
 
     if (sanitizeUrl) {
       if (href.startsWith('javascript:') || href.startsWith('vbscript:') || href.startsWith('data:')) {
@@ -89,8 +89,8 @@ class Renderer extends MarkedRenderer {
 
   // Prepend root to image path
   image(href, title, text) {
+    const { hexo, options } = this;
     const { relative_link } = hexo.config;
-    const { options } = this;
     const { lazyload, prependRoot, postId } = options;
 
     if (!relative_link && prependRoot) {
@@ -118,14 +118,12 @@ marked.setOptions({
 });
 
 module.exports = function(data, options) {
-  hexo = this;
-
   const { post_asset_folder, marked: markedCfg } = this.config;
   const { prependRoot, postAsset } = markedCfg;
   const { path, text } = data;
 
   // exec filter to extend renderer.
-  const renderer = new Renderer();
+  const renderer = new Renderer(this);
   this.execFilterSync('marked:renderer', renderer, {context: this});
 
   let postId = '';

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -93,8 +93,8 @@ class Renderer extends MarkedRenderer {
     const { relative_link } = hexo.config;
     const { lazyload, prependRoot, postId } = options;
 
-    if (!relative_link && prependRoot) {
-      if (postId) {
+    if (!/^(#|\/\/|http(s)?:)/.test(href) && !relative_link && prependRoot) {
+      if (!/^(\/|\\)/.test(href) && postId) {
         const PostAsset = hexo.model('PostAsset');
         // slug requires platform-specific path
         const asset = PostAsset.findOne({ post: postId, slug: href.replace(/\/|\\/g, sep) });

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -4,7 +4,8 @@ const marked = require('marked');
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
 const { parse } = require('url');
-const { join, relative } = require('path').posix;
+const { sep } = require('path');
+let hexo;
 
 const anchorId = (str, transformOption) => {
   return slugize(str.trim(), {transform: transformOption});
@@ -85,17 +86,24 @@ class Renderer extends MarkedRenderer {
   // Prepend root to image path
   image(href, title, text) {
     const { options } = this;
+    const { relative_link } = hexo.config;
+    const { lazyload, prependRoot, postId } = options;
+    const { hostname } = parse(href);
 
-    if (!parse(href).hostname && !options.config.relative_link
-      && options.prependRoot) {
-      if (options.path) href = join(options.path, href);
+    if (!hostname && !relative_link && prependRoot) {
+      if (postId) {
+        const PostAsset = hexo.model('PostAsset');
+        // slug requires platform-specific path
+        const asset = PostAsset.findOne({ post: postId, slug: href.replace(/\/|\\/g, sep) });
+        if (asset) href = encodeURL(('/' + asset.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
+      }
       href = url_for.call(options, href);
     }
 
     let out = `<img src="${encodeURL(href)}"`;
     if (text) out += ` alt="${text}"`;
     if (title) out += ` title="${title}"`;
-    if (options.lazyload) out += ' loading="lazy"';
+    if (lazyload) out += ' loading="lazy"';
 
     out += '>';
     return out;
@@ -123,7 +131,8 @@ module.exports = function(data, options) {
   let path = '';
   if (data.path && this.config.post_asset_folder && this.config.marked.prependRoot && this.config.marked.postAsset) {
     const Post = this.model('Post');
-    const source = relative(this.source_dir, data.path);
+    // Windows compatibility, Post.findOne() requires forward slash
+    const source = data.path.replace(this.source_dir, '').replace('\\', '/');
     const post = Post.findOne({ source });
     path = post ? post.path : '';
   }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -19,12 +19,16 @@ class Renderer extends MarkedRenderer {
 
   // Add id attribute to headings
   heading(text, level) {
-    if (!this.options.headerIds) {
+    const { headerIds, modifyAnchors } = this.options;
+    const { _headingId } = this;
+
+    if (!headerIds) {
       return `<h${level}>${text}</h${level}>`;
     }
-    const transformOption = this.options.modifyAnchors;
+
+    const transformOption = modifyAnchors;
     let id = anchorId(stripHTML(text), transformOption);
-    const headingId = this._headingId;
+    const headingId = _headingId;
 
     // Add a number after id if repeated
     if (headingId[id]) {
@@ -39,14 +43,15 @@ class Renderer extends MarkedRenderer {
 
   // Support AutoLink option
   link(href, title, text) {
-    const { options } = this;
-    const { external_link } = options;
-    if (options.sanitizeUrl) {
+    const { autolink, external_link, sanitizeUrl } = this.options;
+    const { url: urlCfg } = hexo.config;
+
+    if (sanitizeUrl) {
       if (href.startsWith('javascript:') || href.startsWith('vbscript:') || href.startsWith('data:')) {
         href = '';
       }
     }
-    if (!options.autolink && href === text && title == null) {
+    if (!autolink && href === text && title == null) {
       return href;
     }
 
@@ -58,7 +63,7 @@ class Renderer extends MarkedRenderer {
       const target = ' target="_blank"';
       const noopener = ' rel="noopener"';
       const nofollowTag = ' rel="noopener external nofollow noreferrer"';
-      if (isExternalLink(href, options.config.url, external_link.exclude)) {
+      if (isExternalLink(href, urlCfg, external_link.exclude)) {
         if (external_link.enable && external_link.nofollow) {
           out += target + nofollowTag;
         } else if (external_link.enable) {
@@ -85,6 +90,7 @@ class Renderer extends MarkedRenderer {
 
   // Prepend root to image path
   image(href, title, text) {
+    const { relative_link } = hexo.config;
     const { options } = this;
     const { relative_link } = hexo.config;
     const { lazyload, prependRoot, postId } = options;
@@ -117,20 +123,24 @@ marked.setOptions({
 module.exports = function(data, options) {
   hexo = this;
 
+  const { post_asset_folder, marked: markedCfg } = this.config;
+  const { prependRoot, postAsset } = markedCfg;
+  const { path, text } = data;
+
   // exec filter to extend renderer.
   const renderer = new Renderer();
   this.execFilterSync('marked:renderer', renderer, {context: this});
 
   let postId = '';
-  if (data.path && this.config.post_asset_folder && this.config.marked.prependRoot && this.config.marked.postAsset) {
+  if (path && post_asset_folder && prependRoot && postAsset) {
     const Post = this.model('Post');
     // Windows compatibility, Post.findOne() requires forward slash
-    const source = data.path.replace(this.source_dir, '').replace('\\', '/');
+    const source = path.replace(this.source_dir, '').replace('\\', '/');
     const post = Post.findOne({ source });
     postId = post ? post._id : '';
   }
 
-  return marked(data.text, Object.assign({
+  return marked(text, Object.assign({
     renderer
-  }, this.config.marked, options, { postId }));
+  }, markedCfg, options, { postId }));
 };

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -115,29 +115,22 @@ marked.setOptions({
 });
 
 module.exports = function(data, options) {
-  const siteCfg = Object.assign({}, {
-    config: {
-      url: this.config.url,
-      root: this.config.root,
-      relative_link: this.config.relative_link,
-      post_asset_folder: this.config.post_asset_folder
-    }
-  });
+  hexo = this;
 
   // exec filter to extend renderer.
   const renderer = new Renderer();
   this.execFilterSync('marked:renderer', renderer, {context: this});
 
-  let path = '';
+  let postId = '';
   if (data.path && this.config.post_asset_folder && this.config.marked.prependRoot && this.config.marked.postAsset) {
     const Post = this.model('Post');
     // Windows compatibility, Post.findOne() requires forward slash
     const source = data.path.replace(this.source_dir, '').replace('\\', '/');
     const post = Post.findOne({ source });
-    path = post ? post.path : '';
+    postId = post ? post._id : '';
   }
 
   return marked(data.text, Object.assign({
     renderer
-  }, this.config.marked, options, siteCfg, { path }));
+  }, this.config.marked, options, { postId }));
 };

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -3,7 +3,6 @@
 const marked = require('marked');
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
-const { parse } = require('url');
 const { sep } = require('path');
 let hexo;
 
@@ -93,16 +92,15 @@ class Renderer extends MarkedRenderer {
     const { relative_link } = hexo.config;
     const { options } = this;
     const { lazyload, prependRoot, postId } = options;
-    const { hostname } = parse(href);
 
-    if (!hostname && !relative_link && prependRoot) {
+    if (!relative_link && prependRoot) {
       if (postId) {
         const PostAsset = hexo.model('PostAsset');
         // slug requires platform-specific path
         const asset = PostAsset.findOne({ post: postId, slug: href.replace(/\/|\\/g, sep) });
         if (asset) href = encodeURL(('/' + asset.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
       }
-      href = url_for.call(options, href);
+      href = url_for.call(hexo, href);
     }
 
     let out = `<img src="${encodeURL(href)}"`;

--- a/test/index.js
+++ b/test/index.js
@@ -638,6 +638,8 @@ describe('Marked renderer', () => {
   describe('exec filter to extend', () => {
     it('should execute filter registered to marked:renderer', () => {
       const hexo = new Hexo(__dirname, {silent: true});
+      hexo.config.marked = {};
+
       hexo.extend.filter.register('marked:renderer', renderer => {
         renderer.image = function(href, title, text) {
           return `<img data-src="${encodeURL(href)}">`;

--- a/test/source/_posts/foo.md
+++ b/test/source/_posts/foo.md
@@ -1,8 +1,0 @@
----
-layout: post
-title: foo
-date: 2020-08-15 08:32:58
-tags:
----
-
-![](foo.svg)

--- a/test/source/_posts/foo.md
+++ b/test/source/_posts/foo.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: foo
+date: 2020-08-15 08:32:58
+tags:
+---
+
+![](foo.svg)


### PR DESCRIPTION
Fixes https://github.com/hexojs/hexo/issues/4454 cc @v-tawe 

How to use:

``` yml
#_config.yml
post_asset_folder: true
marked:
  prependRoot: true
  postAsset: true
```

Based on [`asset_img`](https://github.com/hexojs/hexo/blob/382b0deef4ea6906a58c7828a70d4b3bebb5b2da/lib/plugins/tag/asset_img.js) tag plugin.