### PR TITLE
fix: autolink option should not apply on markdown syntax

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const marked = require('marked');
+const { escape } = require('marked/src/helpers');
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
+const MarkedTokenizer = marked.Tokenizer;
 
 const anchorId = (str, transformOption) => {
   return slugize(str.trim(), {transform: transformOption});
@@ -39,18 +41,14 @@ class Renderer extends MarkedRenderer {
     return `<h${level} id="${id}"><a href="#${id}" class="headerlink" title="${stripHTML(text)}"></a>${text}</h${level}>`;
   }
 
-  // Support AutoLink option
   link(href, title, text) {
-    const { autolink, external_link, sanitizeUrl } = this.options;
+    const { external_link, sanitizeUrl } = this.options;
     const { url: urlCfg } = this.hexo.config;
 
     if (sanitizeUrl) {
       if (href.startsWith('javascript:') || href.startsWith('vbscript:') || href.startsWith('data:')) {
         href = '';
       }
-    }
-    if (!autolink && href === text && title == null) {
-      return href;
     }
 
     let out = `<a href="${encodeURL(href)}"`;
@@ -117,6 +115,53 @@ marked.setOptions({
   langPrefix: ''
 });
 
+class Tokenizer extends MarkedTokenizer {
+  // Support AutoLink option
+  // https://github.com/markedjs/marked/blob/b6773fca412c339e0cedd56b63f9fa1583cfd372/src/Tokenizer.js#L606-L641
+  url(src, mangle) {
+    const { options, rules } = this;
+    const { mangle: isMangle, autolink } = options;
+
+    if (!autolink) return;
+
+    const cap = rules.inline.url.exec(src);
+    if (cap) {
+      let text, href;
+      if (cap[2] === '@') {
+        text = escape(isMangle ? mangle(cap[0]) : cap[0]);
+        href = 'mailto:' + text;
+      } else {
+        // do extended autolink path validation
+        let prevCapZero;
+        do {
+          prevCapZero = cap[0];
+          cap[0] = rules.inline._backpedal.exec(cap[0])[0];
+        } while (prevCapZero !== cap[0]);
+        text = escape(cap[0]);
+        if (cap[1] === 'www.') {
+          href = 'http://' + text;
+        } else {
+          href = text;
+        }
+      }
+
+      return {
+        type: 'link',
+        raw: cap[0],
+        text,
+        href,
+        tokens: [
+          {
+            type: 'text',
+            raw: text,
+            text
+          }
+        ]
+      };
+    }
+  }
+}
+
 module.exports = function(data, options) {
   const { post_asset_folder, marked: markedCfg, source_dir } = this.config;
   const { prependRoot, postAsset } = markedCfg;
@@ -125,6 +170,8 @@ module.exports = function(data, options) {
   // exec filter to extend renderer.
   const renderer = new Renderer(this);
   this.execFilterSync('marked:renderer', renderer, {context: this});
+
+  const tokenizer = new Tokenizer();
 
   let postPath = '';
   if (path && post_asset_folder && prependRoot && postAsset) {
@@ -136,6 +183,7 @@ module.exports = function(data, options) {
   }
 
   return marked(text, Object.assign({
-    renderer
+    renderer,
+    tokenizer
   }, markedCfg, options, { postPath }));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -165,16 +165,25 @@ describe('Marked renderer', () => {
     const body = [
       'Great website http://hexo.io',
       '',
-      '[Hexo](http://hexo.io)'
+      'A webpage www.example.com',
+      '',
+      '[Hexo](http://hexo.io)',
+      '',
+      '[http://lorem.com/foo/](http://lorem.com/foo/)',
+      '',
+      '<http://dolor.com>'
     ].join('\n');
 
     it('autolink enabled', () => {
       const result = r({text: body});
 
       result.should.eql([
-        '<p>Great website <a href="http://hexo.io/">http://hexo.io</a></p>\n',
-        '<p><a href="http://hexo.io/">Hexo</a></p>\n'
-      ].join(''));
+        '<p>Great website <a href="http://hexo.io/">http://hexo.io</a></p>',
+        '<p>A webpage <a href="http://www.example.com/">www.example.com</a></p>',
+        '<p><a href="http://hexo.io/">Hexo</a></p>',
+        '<p><a href="http://lorem.com/foo/">http://lorem.com/foo/</a></p>',
+        '<p><a href="http://dolor.com/">http://dolor.com</a></p>'
+      ].join('\n') + '\n');
     });
 
     it('autolink disabled', () => {
@@ -182,9 +191,12 @@ describe('Marked renderer', () => {
       const result = r({text: body});
 
       result.should.eql([
-        '<p>Great website http://hexo.io</p>\n',
-        '<p><a href="http://hexo.io/">Hexo</a></p>\n'
-      ].join(''));
+        '<p>Great website http://hexo.io</p>',
+        '<p>A webpage www.example.com</p>',
+        '<p><a href="http://hexo.io/">Hexo</a></p>',
+        '<p><a href="http://lorem.com/foo/">http://lorem.com/foo/</a></p>',
+        '<p><a href="http://dolor.com/">http://dolor.com</a></p>'
+      ].join('\n') + '\n');
     });
   });
 


### PR DESCRIPTION
[`link`](https://marked.js.org/#/USING_PRO.md#inline-level-renderer-methods) renderer method couldn't discern whether a link is inside `[]()`, `<>`, `http://example.com` or `www.example.com`.

Meanwhile, [`url`](https://marked.js.org/#/USING_PRO.md#inline-level-tokenizer-methods) tokenizer is the method responsible for detecting `http://example.com` or `www.example.com`, so `autolink` option is more suitable there. (marked doesn't detect `example.com`, if a link doesn't starts with protocol (e.g. `http://`), a link must starts with www to be detected).

Fixes #139 