### PR TITLE
feat: mangle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ marked:
   quotes: '“”‘’'
   modifyAnchors: 0
   autolink: true
+  mangle: true
   sanitizeUrl: false
   headerIds: true
   lazyload: false
@@ -53,6 +54,8 @@ marked:
   * Both double and single quotes substitution must be specified, otherwise it will be silently ignored.
 - **modifyAnchors** - Transform the anchorIds into lower case (`1`) or upper case (`2`).
 - **autolink** - Enable autolink for URLs. E.g. `https://hexo.io` will become `<a href="https://hexo.io">https://hexo.io</a>`.
+- **mangle** - Escape autolinked email address with HTML character references.
+  * This is to obscure email address from _basic_ crawler used by spam bot, while still readable to web browsers.
 - **sanitizeUrl** - Remove URLs that start with `javascript:`, `vbscript:` and `data:`.
 - **headerIds** - Insert header id, e.g. `<h1 id="value">text</h1>`. Useful for inserting anchor link to each paragraph with a heading.
 - **lazyload** - Lazy loading images via `loading="lazy"` attribute.
@@ -72,6 +75,8 @@ marked:
     - Example: `[foo](http://bar.com)` becomes `<a href="http://bar.com" target="_blank" rel="noopener">foo</a>`
   * **nofollow** - Add `rel="noopener external nofollow noreferrer"` to all external links for security, privacy and SEO. [Read more](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types). _This can be enabled regardless of `external_link.enable`_
     - Example: `[foo](http://bar.com)` becomes `<a href="http://bar.com" rel="noopener external nofollow noreferrer">foo</a>`
+
+For more options, see [Marked](https://marked.js.org/using_advanced#options). Due to the customizations implemented by this plugin, some of the Marked's options may not work as expected. Feel free to raise an [issue](https://github.com/hexojs/hexo-renderer-marked/issues) to us for clarification.
 
 ## Extras
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ hexo.config.marked = Object.assign({
   smartypants: true,
   modifyAnchors: 0,
   autolink: true,
+  mangle: true,
   sanitizeUrl: false,
   headerIds: true,
   lazyload: false,

--- a/test/index.js
+++ b/test/index.js
@@ -307,6 +307,43 @@ describe('Marked renderer', () => {
     });
   });
 
+  describe('mangle', () => {
+    const body = 'Contact: hi@example.com';
+    const expected = '<p>Contact: <a href="mailto:hi@example.com">hi@example.com</a></p>\n';
+    // https://stackoverflow.com/a/39243641
+    const unescape = str => {
+      return str.replace(/&([^;]+);/g, (entity, entityCode) => {
+        const hex = entityCode.match(/^#x([\da-fA-F]+)$/);
+        const digit = entityCode.match(/^#(\d+)$/);
+
+        if (hex) {
+          return String.fromCharCode(parseInt(hex[1], 16));
+        } else if (digit) {
+          return String.fromCharCode(~~digit[1]);
+        }
+        return entity;
+
+      });
+    };
+
+    // mangle option only applies to autolinked email address
+    beforeEach(() => { hexo.config.marked.autolink = true; });
+
+    it('default', () => {
+      const result = r({text: body});
+
+      result.should.include('&#');
+      unescape(result).should.eql(expected);
+    });
+
+    it('disabled', () => {
+      hexo.config.marked.mangle = false;
+      const result = r({text: body});
+
+      result.should.eql(expected);
+    });
+  });
+
   it('should render link with title', () => {
     const body = [
       '[text](http://link.com/ "a-title")',


### PR DESCRIPTION
built-in [option](https://marked.js.org/using_advanced#options) of marked, this is just exposing to renderer config.