### PR TITLE
fix(postAsset): post may be in a subfolder

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -5,6 +5,7 @@ const { escape } = require('marked/src/helpers');
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink } = require('hexo-util');
 const MarkedRenderer = marked.Renderer;
 const MarkedTokenizer = marked.Tokenizer;
+const { basename, dirname, extname, join } = require('path').posix;
 
 const anchorId = (str, transformOption) => {
   return slugize(str.trim(), {transform: transformOption});
@@ -103,7 +104,7 @@ class Renderer extends MarkedRenderer {
       if (!href.startsWith('/') && !href.startsWith('\\') && postPath) {
         const PostAsset = hexo.model('PostAsset');
         // findById requires forward slash
-        const asset = PostAsset.findById(postPath + href.replace(/\\/g, '/'));
+        const asset = PostAsset.findById(join(postPath, href.replace(/\\/g, '/')));
         // asset.path is backward slash in Windows
         if (asset) href = asset.path.replace(/\\/g, '/');
       }
@@ -234,7 +235,10 @@ module.exports = function(data, options) {
     // Windows compatibility, Post.findOne() requires forward slash
     const source = path.substring(this.source_dir.length).replace(/\\/g, '/');
     const post = Post.findOne({ source });
-    postPath = post ? source_dir + '/_posts/' + post.slug + '/' : '';
+    if (post) {
+      const { source: postSource } = post;
+      postPath = join(source_dir, dirname(postSource), basename(postSource, extname(postSource)));
+    }
   }
 
   return marked(text, Object.assign({

--- a/test/index.js
+++ b/test/index.js
@@ -756,7 +756,7 @@ describe('Marked renderer', () => {
       };
     });
 
-    it('should prepend post path', async () => {
+    it('default', async () => {
       const asset = 'img/bar.svg';
       const slug = asset.replace(/\//g, sep);
       const content = `![](${asset})`;
@@ -802,6 +802,29 @@ describe('Marked renderer', () => {
         `<img src="${siteasset}">`,
         `<img src="${site}"></p>`
       ].join('\n') + '\n');
+
+      await PostAsset.removeById(postasset._id);
+      await Post.removeById(post._id);
+    });
+
+    // #170
+    it('post located in subfolder', async () => {
+      const asset = 'img/bar.svg';
+      const slug = asset.replace(/\//g, sep);
+      const content = `![](${asset})`;
+      const post = await Post.insert({
+        source: '_posts/lorem/foo.md',
+        slug: 'foo'
+      });
+      const postasset = await PostAsset.insert({
+        _id: `source/_posts/lorem/foo/${asset}`,
+        slug,
+        post: post._id
+      });
+
+      const expected = url_for.call(hexo, join(post.path, asset));
+      const result = r({ text: content, path: post.full_source });
+      result.should.eql(`<p><img src="${expected}"></p>\n`);
 
       await PostAsset.removeById(postasset._id);
       await Post.removeById(post._id);


### PR DESCRIPTION
previously it was assumed that all posts are in top folder of `source/_posts/`, but in reality, posts could be in any subfolder of `_posts/`.

Closes #170 cc @smalltimer

How to test:

1. `$ npm install hexo-renderer-marked@curbengh/hexo-renderer-marked#postasset-subfolder`
2. `hexo clean`
3. `hexo server`