### PR TITLE
feat: add descriptionLists options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ marked:
     exclude: []
     nofollow: false
   disableNunjucks: false
+  descriptionLists: true
 ```
 
 - **gfm** - Enables [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown)
@@ -82,6 +83,9 @@ marked:
   * **nofollow** - Add `rel="noopener external nofollow noreferrer"` to all external links for security, privacy and SEO. [Read more](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types). _This can be enabled regardless of `external_link.enable`_
     - Example: `[foo](http://bar.com)` becomes `<a href="http://bar.com" rel="noopener external nofollow noreferrer">foo</a>`
 - **disableNunjucks**: If true, Nunjucks tags `{{ }}` or `{% %}` (usually used by [tag plugins](https://hexo.io/docs/tag-plugins)) will not be rendered.
+- **descriptionLists**: Enable support for [description lists syntax](https://kramdown.gettalong.org/syntax.html#definition-lists).
+  * Currently description lists syntax is not in neither [CommonMark](http://commonmark.org/) or [GFM](https://github.github.com/gfm/#task-list-items-extension-), `hexo-renderer-marked` only provides the option for backward compatibility.
+  * By disabling the `descriptionLists`, markdown rendering performance will be improved by **a lot**.
 
 For more options, see [Marked](https://marked.js.org/using_advanced#options). Due to the customizations implemented by this plugin, some of the Marked's options may not work as expected. Feel free to raise an [issue](https://github.com/hexojs/hexo-renderer-marked/issues) to us for clarification.
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ hexo.config.marked = Object.assign({
     enable: false,
     exclude: [],
     nofollow: false
-  }
+  },
+  descriptionLists: true
 }, hexo.config.marked);
 
 renderer.disableNunjucks = Boolean(hexo.config.marked.disableNunjucks);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -7,6 +7,7 @@ const MarkedRenderer = marked.Renderer;
 const MarkedTokenizer = marked.Tokenizer;
 const { basename, dirname, extname, join } = require('path').posix;
 const rATag = /<a(?:\s+?|\s+?[^<>]+\s+?)?href=["'](?:#)([^<>"']+)["'][^<>]*>/i;
+const rDlSyntax = /(?:^|\s)(\S.+)<br>:\s+(\S.+)/;
 
 const anchorId = (str, transformOption) => {
   return slugize(str.trim(), {transform: transformOption});
@@ -99,11 +100,14 @@ class Renderer extends MarkedRenderer {
 
   // Support Basic Description Lists
   paragraph(text) {
-    const dlTest = /(?:^|\s)(\S.+)<br>:\s+(\S.+)/;
-    const dl = '<dl><dt>$1</dt><dd>$2</dd></dl>';
-    if (dlTest.test(text)) {
-      return text.replace(dlTest, dl);
+    const { descriptionLists = true } = this.options;
+
+    if (descriptionLists) {
+      if (rDlSyntax.test(text)) {
+        return text.replace(rDlSyntax, '<dl><dt>$1</dt><dd>$2</dd></dl>');
+      }
     }
+
     return `<p>${text}</p>\n`;
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -140,6 +140,12 @@ describe('Marked renderer', () => {
   });
 
   // Description List tests
+  it('shouldn\'t render description lists when options.descriptionLists is disabled', () => {
+    hexo.config.marked.descriptionLists = false;
+
+    const result = r({text: 'Description Term<br>: This is the Description'});
+    result.should.eql('<p>Description Term<br>: This is the Description</p>\n');
+  });
 
   it('should render description lists with a single space after the colon', () => {
     const result = r({text: 'Description Term<br>: This is the Description'});


### PR DESCRIPTION
This provides an option for `<dl>` support. Currently, the option is enabled by default for backward compatibility, but disable it will gain a lot of performance, thus here goes the PR. We should disable it v4 by default for better performance.