### PR TITLE
release: v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-renderer-marked",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Markdown renderer plugin for Hexo",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
We merged marked `v2.0.0`.

> #183 

As marked v2.0.0's release note, tokenizers were changed.

> https://github.com/markedjs/marked/releases/tag/v2.0.0

IMHO we should bump the major version.

Thank you :)