### PR TITLE
refactor: call parent class url tokenizer method

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -171,48 +171,12 @@ const smartypants = (str, quotes) => {
 
 class Tokenizer extends MarkedTokenizer {
   // Support AutoLink option
-  // https://github.com/markedjs/marked/blob/b6773fca412c339e0cedd56b63f9fa1583cfd372/src/Tokenizer.js#L606-L641
   url(src, mangle) {
-    const { options, rules } = this;
-    const { mangle: isMangle, autolink } = options;
+    const { options } = this;
+    const { autolink } = options;
 
     if (!autolink) return;
-
-    const cap = rules.inline.url.exec(src);
-    if (cap) {
-      let text, href;
-      if (cap[2] === '@') {
-        text = escape(isMangle ? mangle(cap[0]) : cap[0]);
-        href = 'mailto:' + text;
-      } else {
-        // do extended autolink path validation
-        let prevCapZero;
-        do {
-          prevCapZero = cap[0];
-          cap[0] = rules.inline._backpedal.exec(cap[0])[0];
-        } while (prevCapZero !== cap[0]);
-        text = escape(cap[0]);
-        if (cap[1] === 'www.') {
-          href = 'http://' + text;
-        } else {
-          href = text;
-        }
-      }
-
-      return {
-        type: 'link',
-        raw: cap[0],
-        text,
-        href,
-        tokens: [
-          {
-            type: 'text',
-            raw: text,
-            text
-          }
-        ]
-      };
-    }
+    return super.url(src, mangle);
   }
 
   // Override smartypants


### PR DESCRIPTION
The many lines of the current `Tokenizer.url` (extends from MarkedTokenizer) method seems just copy from marked's `Tokenizer.url` method.

It is very costly when update marked dependency.
I think just call super class method is enough.
