### PR TITLE
feat: new option figcaption

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ marked:
   dompurify: false
   headerIds: true
   lazyload: false
+  figcaption: false
   prependRoot: true
   postAsset: false
   external_link:
@@ -79,6 +80,7 @@ marked:
   * Example: `## [foo](#bar)`, id will be set as "bar".
   * Requires **headerIds** to be enabled.
 - **lazyload** - Lazy loading images via `loading="lazy"` attribute.
+- **figcaption** - Append `figcaption` element after each image.
 - **prependRoot** - Prepend root value to (internal) image path.
   * Example `_config.yml`:
   ``` yml

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -138,8 +138,7 @@ class Renderer extends MarkedRenderer {
 
     out += '>';
     if (figcaption) {
-      const caption = text || title;
-      if (caption) out += `<figcaption aria-hidden="true">${caption}</figcaption>`;
+      if (text) out += `<figcaption aria-hidden="true">${text}</figcaption>`;
     }
     return out;
   }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -118,7 +118,7 @@ class Renderer extends MarkedRenderer {
   image(href, title, text) {
     const { hexo, options } = this;
     const { relative_link } = hexo.config;
-    const { lazyload, prependRoot, postPath } = options;
+    const { lazyload, figcaption, prependRoot, postPath } = options;
 
     if (!/^(#|\/\/|http(s)?:)/.test(href) && !relative_link && prependRoot) {
       if (!href.startsWith('/') && !href.startsWith('\\') && postPath) {
@@ -137,6 +137,10 @@ class Renderer extends MarkedRenderer {
     if (lazyload) out += ' loading="lazy"';
 
     out += '>';
+    if (figcaption) {
+      const caption = text || title;
+      if (caption) out += `<figcaption aria-hidden="true">${caption}</figcaption>`;
+    }
     return out;
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -793,8 +793,8 @@ describe('Marked renderer', () => {
 
   it('figcaption', () => {
     const body = [
-      '![](/bar/baz.jpg)',
-      '![](/bar/baz.jpg "foo")',
+      '![](/bar/baz.jpg "bar")',
+      '![foo](/bar/baz.jpg "bar")',
       '![foo](/aaa/bbb.jpg)'
     ].join('\n');
 
@@ -805,8 +805,8 @@ describe('Marked renderer', () => {
     const result = r({ text: body });
 
     result.should.eql([
-      '<p><img src="/bar/baz.jpg">',
-      '<img src="/bar/baz.jpg" title="foo"><figcaption aria-hidden="true">foo</figcaption>',
+      '<p><img src="/bar/baz.jpg" title="bar">',
+      '<img src="/bar/baz.jpg" alt="foo" title="bar"><figcaption aria-hidden="true">foo</figcaption>',
       '<img src="/aaa/bbb.jpg" alt="foo"><figcaption aria-hidden="true">foo</figcaption></p>\n'
     ].join('\n'));
   });

--- a/test/index.js
+++ b/test/index.js
@@ -791,6 +791,26 @@ describe('Marked renderer', () => {
     ].join('\n'));
   });
 
+  it('figcaption', () => {
+    const body = [
+      '![](/bar/baz.jpg)',
+      '![](/bar/baz.jpg "foo")',
+      '![foo](/aaa/bbb.jpg)'
+    ].join('\n');
+
+    hexo.config.marked.figcaption = true;
+
+    const r = require('../lib/renderer').bind(hexo);
+
+    const result = r({ text: body });
+
+    result.should.eql([
+      '<p><img src="/bar/baz.jpg">',
+      '<img src="/bar/baz.jpg" title="foo"><figcaption aria-hidden="true">foo</figcaption>',
+      '<img src="/aaa/bbb.jpg" alt="foo"><figcaption aria-hidden="true">foo</figcaption></p>\n'
+    ].join('\n'));
+  });
+
   describe('postAsset', () => {
     const Post = hexo.model('Post');
     const PostAsset = hexo.model('PostAsset');


### PR DESCRIPTION
Append `figcaption` element after each image.
This feature is supported by other renderers, e.g. hexo-renderer-pandoc.
https://pandoc.org/MANUAL.html#extension-implicit_figures