### PR TITLE
Add more asset-searching locations and solves a known issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ marked:
   ```
   * `![text](/path/to/image.jpg)` becomes `<img src="/blog/path/to/image.jpg" alt="text">`
 - **postAsset** - Resolve post asset's image path to relative path and prepend root value when [`post_asset_folder`](https://hexo.io/docs/asset-folders) is enabled.
-  * "image.jpg" is located at "/2020/01/02/foo/image.jpg", which is a post asset of "/2020/01/02/foo/".
-  * `![](image.jpg)` becomes `<img src="/2020/01/02/foo/image.jpg">`
+  * Search for assets first in the post asset folder, then the parent folder of the post asset folder. The search process is aborted once the image is found.
+  * "image.jpg" is located at "/2020/01/02/foo/image.jpg" and locally `source/_post/foo/image.jpg` , which is a post asset of "/2020/01/02/foo/".
+  * `![](image.jpg)` becomes `<img src="/2020/01/02/foo/image.jpg">` (asset is found in post asset folder since `source/_post/foo` `/` `image.jpg` exists.)
+  * `![](foo/image.jpg)` also becomes `<img src="/2020/01/02/foo/image.jpg">` (asset is found in the parent folder of post asset folder since `source/_post` `/` `foo/image.jpg` exists.)
   * Requires **prependRoot** to be enabled.
 - **external_link**
   * **enable** - Open external links in a new tab.

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -119,14 +119,22 @@ class Renderer extends MarkedRenderer {
     const { hexo, options } = this;
     const { relative_link } = hexo.config;
     const { lazyload, figcaption, prependRoot, postPath } = options;
+    const searchAssetLocation = ['./', '../'];
 
     if (!/^(#|\/\/|http(s)?:)/.test(href) && !relative_link && prependRoot) {
       if (!href.startsWith('/') && !href.startsWith('\\') && postPath) {
         const PostAsset = hexo.model('PostAsset');
-        // findById requires forward slash
-        const asset = PostAsset.findById(join(postPath, href.replace(/\\/g, '/')));
-        // asset.path is backward slash in Windows
-        if (asset) href = asset.path.replace(/\\/g, '/');
+        for (let appendPath of searchAssetLocation){
+          const destPath = join(postPath, appendPath);
+          // findById requires forward slash
+          const asset = PostAsset.findById(join(destPath, href.replace(/\\/g, '/')));
+          // asset.path is backward slash in Windows
+          if (asset) {
+            href = asset.path.replace(/\\/g, '/');
+            // asset is found, stop searching
+            break;
+          }
+        }
       }
       href = url_for.call(hexo, href);
     }


### PR DESCRIPTION
This solves the issue #216.  

Until now, if I would like to insert an image named `image.jpg` in a post with a file name `foo.md` with these configurations:
```yaml
post_asset_folder: true
relative_link: false
marked:
  prependRoot: true
  postAsset: true
```
and the filesystem structure:
```shell
source/_posts
├── foo.md
└── foo
    └── image.jpg
```
I have to use `![](image.jpg)` instead of `![](foo/image.jpg)` otherwise hexo would not generate a valid img src. However, if I would like to preview the markdown file while editing, I have to use the latter one. This is contradictory.  

So I made a modification to allow `hexo-renderer-marked` to search for assets not only in current asset folder `source/_posts/foo`, but also in its parent folder `source/_posts`, so that `![](foo/image.jpg)` can also be located and the src can be generated correctly.  

Moreover, this change is compatible with the previous versions and developers can safely update the package to a new version without the need for changing each and every link in their blogs.  

Notice: the changes have passed the tests on Linux (WSL2, Ubuntu 22.04).  

I hope these changes are acceptable.