### PR TITLE
Added filter marked:use for direct access to the marked.use function

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,17 @@ hexo.extend.filter.register('marked:extensions', function(extensions) {
 });
 ```
 
+You may also get access to `marked.use` function.
+For example to use the [marked-alert](https://github.com/bent10/marked-extensions/tree/main/packages/alert) extention wich also provides a `walkTokens` functions:
+
+```js
+const markedAlert = require('marked-alert');
+
+hexo.extend.filter.register('marked:use', function (markedUse) {
+  markedUse(markedAlert());
+});
+```
+
 [Markdown]: https://daringfireball.net/projects/markdown/
 [marked]: https://github.com/chjj/marked
 [PHP Markdown Extra]: https://michelf.ca/projects/php-markdown/extra/#def-list

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -209,6 +209,9 @@ module.exports = function(data, options) {
   const { prependRoot, postAsset, dompurify } = markedCfg;
   const { path, text } = data;
 
+  // exec filter to extend marked
+  this.execFilterSync('marked:use', marked.use, { context: this });
+
   // exec filter to extend renderer.
   const renderer = new Renderer(this);
   this.execFilterSync('marked:renderer', renderer, { context: this });


### PR DESCRIPTION
Background:
The [marked-alert](https://github.com/bent10/marked-extensions/tree/main/packages/alert) extension enables usage of [GFM alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).
To use this extension (and maybe some others) the current `marked:extensions` filter is not enough since it only provides the `extensions` property but the altert extension also requires `walkTokens` to be set in `marked.use(...)`.

This PR adds a `marked:use` filter allowing the usage of the `marked.use` function in a theme.

Usage example:
```js
const markedAlert = require('marked-alert');

hexo.extend.filter.register('marked:use', function (markedUse) {
  markedUse(markedAlert());
});
```