### PR TITLE
chore(deps): adapt to marked@12

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -6,8 +6,6 @@ let JSDOM,
   createDOMPurify;
 
 const { encodeURL, slugize, stripHTML, url_for, isExternalLink, escapeHTML: escape, unescapeHTML: unescape } = require('hexo-util');
-const MarkedRenderer = marked.Renderer;
-const MarkedTokenizer = marked.Tokenizer;
 const { basename, dirname, extname, join } = require('path').posix;
 const rATag = /<a(?:\s+?|\s+?[^<>]+\s+?)?href=["'](?:#)([^<>"']+)["'][^<>]*>/i;
 const rDlSyntax = /(?:^|\s)(\S.+)<br>:\s+(\S.+)/;
@@ -16,17 +14,27 @@ const anchorId = (str, transformOption) => {
   return slugize(stripHTML(unescape(str)).trim(), { transform: transformOption });
 };
 
-class Renderer extends MarkedRenderer {
-  constructor(hexo) {
-    super();
-    this._headingId = {};
-    this.hexo = hexo;
+function mangleEmail(text) {
+  let out = '';
+  let i,
+    ch;
+
+  const l = text.length;
+  for (i = 0; i < l; i++) {
+    ch = text.charCodeAt(i);
+    if (Math.random() > 0.5) {
+      ch = 'x' + ch.toString(16);
+    }
+    out += '&#' + ch + ';';
   }
 
+  return out;
+}
+
+const renderer = {
   // Add id attribute to headings
   heading(text, level) {
-    const { anchorAlias, headerIds, modifyAnchors } = this.options;
-    const { _headingId } = this;
+    const { anchorAlias, headerIds, modifyAnchors, _headingId } = this.options;
 
     if (!headerIds) {
       return `<h${level}>${text}</h${level}>`;
@@ -57,15 +65,23 @@ class Renderer extends MarkedRenderer {
 
     // add headerlink
     return `<h${level} id="${id}"><a href="#${id}" class="headerlink" title="${stripHTML(text)}"></a>${text}</h${level}>`;
-  }
+  },
 
   link(href, title, text) {
-    const { external_link, sanitizeUrl } = this.options;
-    const { url: urlCfg } = this.hexo.config;
+    const { external_link, sanitizeUrl, hexo, mangle } = this.options;
+    const { url: urlCfg } = hexo.config;
 
     if (sanitizeUrl) {
       if (href.startsWith('javascript:') || href.startsWith('vbscript:') || href.startsWith('data:')) {
         href = '';
+      }
+    }
+    if (mangle) {
+      if (href.startsWith('mailto:')) {
+        const email = href.substring(7);
+        const mangledEmail = mangleEmail(email);
+
+        href = `mailto:${mangledEmail}`;
       }
     }
 
@@ -99,7 +115,7 @@ class Renderer extends MarkedRenderer {
 
     out += `>${text}</a>`;
     return out;
-  }
+  },
 
   // Support Basic Description Lists
   paragraph(text) {
@@ -112,11 +128,12 @@ class Renderer extends MarkedRenderer {
     }
 
     return `<p>${text}</p>\n`;
-  }
+  },
 
   // Prepend root to image path
   image(href, title, text) {
-    const { hexo, options } = this;
+    const { options } = this;
+    const { hexo } = options;
     const { relative_link } = hexo.config;
     const { lazyload, figcaption, prependRoot, postPath } = options;
 
@@ -142,11 +159,7 @@ class Renderer extends MarkedRenderer {
     }
     return out;
   }
-}
-
-marked.setOptions({
-  langPrefix: ''
-});
+};
 
 // https://github.com/markedjs/marked/blob/b6773fca412c339e0cedd56b63f9fa1583cfd372/src/Lexer.js#L8-L24
 const smartypants = (str, quotes) => {
@@ -171,15 +184,15 @@ const smartypants = (str, quotes) => {
     .replace(/\.{3}/g, '\u2026');
 };
 
-class Tokenizer extends MarkedTokenizer {
+const tokenizer = {
   // Support AutoLink option
-  url(src, mangle) {
-    const { options } = this;
-    const { autolink } = options;
+  url(src) {
+    const { autolink } = this.options;
 
     if (!autolink) return;
-    return super.url(src, mangle);
-  }
+    // return false to use original url tokenizer
+    return false;
+  },
 
   // Override smartypants
   inlineText(src) {
@@ -202,21 +215,20 @@ class Tokenizer extends MarkedTokenizer {
       };
     }
   }
-}
+};
 
 module.exports = function(data, options) {
   const { post_asset_folder, marked: markedCfg, source_dir } = this.config;
-  const { prependRoot, postAsset, dompurify } = markedCfg;
+  const { prependRoot, postAsset, dompurify, mangle } = markedCfg;
   const { path, text } = data;
 
   // exec filter to extend marked
   this.execFilterSync('marked:use', marked.use, { context: this });
 
   // exec filter to extend renderer.
-  const renderer = new Renderer(this);
   this.execFilterSync('marked:renderer', renderer, { context: this });
 
-  const tokenizer = new Tokenizer();
+  // exec filter to extend tokenizer
   this.execFilterSync('marked:tokenizer', tokenizer, { context: this });
 
   const extensions = [];
@@ -250,8 +262,13 @@ module.exports = function(data, options) {
     }
     sanitizer = function(html) { return DOMPurify.sanitize(html, param); };
   }
-  return sanitizer(marked(text, Object.assign({
+
+  marked.use({
     renderer,
     tokenizer
-  }, markedCfg, options, { postPath })));
+  });
+  return sanitizer(marked.parse(text, Object.assign({
+    // headerIds was removed in marked v8.0.0, but we still need it
+    headerIds: true
+  }, markedCfg, options, { postPath, hexo: this, _headingId: {} })));
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dompurify": "^3.0.3",
     "hexo-util": "^3.1.0",
     "jsdom": "^20.0.1",
-    "marked": "^4.3.0"
+    "marked": "^12.0.1"
   },
   "devDependencies": {
     "c8": "^8.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,10 @@ const { sep } = require('path');
 describe('Marked renderer', () => {
   const hexo = new Hexo(__dirname, {silent: true});
   const defaultCfg = JSON.parse(JSON.stringify(Object.assign(hexo.config, {
-    marked: {}
+    marked: {
+      headerIds: true,
+      mangle: true
+    }
   })));
 
   before(async () => {


### PR DESCRIPTION
Marked has undergone significant upgrades in the past year (the version number quickly jumped from 4 to 12), and many old customization methods no longer apply. This pull request is intended to adapt to the new versions of marked. It's important to note that I have only ensured that all current unit tests can pass; whether it works properly in a real Hexo environment still needs further testing.